### PR TITLE
libipl: Mailbox scratch 3  register updates

### DIFF
--- a/libipl/p10/ipl0.C
+++ b/libipl/p10/ipl0.C
@@ -438,7 +438,7 @@ static int ipl_sbe_config_update(void)
 {
 	struct pdbg_target *root, *proc;
 	int rc = 1;
-	uint8_t istep_mode, core_mode, disable_security;
+	uint8_t istep_mode, core_mode, disable_security, attr_override;
 	fapi2::buffer<uint32_t> boot_flags;
 
 	ipl_log(IPL_INFO, "Istep: sbe_config_update: started\n");
@@ -468,6 +468,16 @@ static int ipl_sbe_config_update(void)
 		boot_flags.setBit(6);
 	else
 		boot_flags.clearBit(6);
+
+	// bit 7 - Allow hostboot attribute overrides. 0b1 indicates enable
+	if (!pdbg_target_get_attribute(root, "ATTR_ALLOW_ATTR_OVERRIDES", 1, 1, &attr_override)) {
+		ipl_log(IPL_ERROR, "Attribute [ATTR_ALLOW_ATTR_OVERRIDES] read failed \n");
+		return 1;
+	}
+	if (attr_override)
+		boot_flags.setBit(7);
+	else
+		boot_flags.clearBit(7);
 
 	if (!pdbg_target_set_attribute(root, "ATTR_BOOT_FLAGS", 4, 1, &boot_flags)) {
 		ipl_log(IPL_ERROR, "Attribute [ATTR_BOOT_FLAGS] update failed \n");

--- a/libipl/p10/ipl0.C
+++ b/libipl/p10/ipl0.C
@@ -439,6 +439,8 @@ static int ipl_sbe_config_update(void)
 	struct pdbg_target *root, *proc;
 	int rc = 1;
 	uint8_t istep_mode, core_mode, disable_security, attr_override;
+	uint8_t scom_allowed;
+
 	fapi2::buffer<uint32_t> boot_flags;
 
 	ipl_log(IPL_INFO, "Istep: sbe_config_update: started\n");
@@ -478,6 +480,16 @@ static int ipl_sbe_config_update(void)
 		boot_flags.setBit(7);
 	else
 		boot_flags.clearBit(7);
+
+	// bit 11 - Disable denial list based SCOM access. 0b1 indicates disable
+	if (!pdbg_target_get_attribute(root, "ATTR_NO_XSCOM_ENFORCEMENT", 1, 1, &scom_allowed)) {
+		ipl_log(IPL_ERROR, "Attribute [ATTR_NO_XSCOM_ENFORCEMENT] read failed \n");
+		return 1;
+	}
+	if (scom_allowed)
+		boot_flags.setBit(11);
+	else
+		boot_flags.clearBit(11);
 
 	if (!pdbg_target_set_attribute(root, "ATTR_BOOT_FLAGS", 4, 1, &boot_flags)) {
 		ipl_log(IPL_ERROR, "Attribute [ATTR_BOOT_FLAGS] update failed \n");


### PR DESCRIPTION
- Added Scratch register 3  updates 
   bit 7 based on ATTR_ALLOW_ATTR_OVERRIDES 
  bit 11 based ATTR_NO_XSCOM_ENFORCEMENT