### PR TITLE
libipl: additional data support in error callback

### DIFF
--- a/libipl/libipl.C
+++ b/libipl/libipl.C
@@ -353,9 +353,9 @@ void ipl_set_error_callback_func(ipl_error_callback_func_t fn)
 	g_ipl_error_callback_fn = fn;
 }
 
-void ipl_error_callback(bool status)
+void ipl_error_callback(bool status, ipl_error_info error)
 {
 	if (!g_ipl_error_callback_fn)
 		return;
-	g_ipl_error_callback_fn(status);
+	g_ipl_error_callback_fn(status, error);
 }

--- a/libipl/libipl.H
+++ b/libipl/libipl.H
@@ -1,6 +1,9 @@
 #ifndef __LIBIPL_H__
 #define __LIBIPL_H__
 
+#include <stdlib.h>
+#include <string>
+
 #define MAX_ISTEP	21
 
 enum ipl_mode {
@@ -21,8 +24,28 @@ enum ipl_type {
 extern "C" {
 #include <stdarg.h>
 
+//IPL Error types
+enum ipl_error_type {
+	IPL_NO_ERROR = 0,
+	IPL_SBE_CHIPOP_FAIL = 1,
+};
+
+// Error info structure.
+struct ipl_error_info {
+	enum ipl_error_type type;
+	void *private_data;  //additional data
+	const std::string msg; //Error messaage
+	~ipl_error_info(){
+		// freeup the private_data allocated memory
+		if (private_data){
+			free(private_data);
+		}
+	}
+};
+
+
 typedef void (*ipl_log_func_t)(void *private_data, const char *fmt, va_list ap);
-typedef void (*ipl_error_callback_func_t)(bool status);
+typedef void (*ipl_error_callback_func_t)(bool status, ipl_error_info error);
 
 int ipl_init(enum ipl_mode mode);
 int ipl_run_major_minor(int major, int minor);

--- a/libipl/libipl_internal.H
+++ b/libipl/libipl_internal.H
@@ -25,5 +25,7 @@ void ipl_pre(void);
 void ipl_register(int major, struct ipl_step *steps, void (*pre_func)(void));
 enum ipl_mode ipl_mode(void);
 
-void ipl_error_callback(bool status);
+void ipl_error_callback(bool status,
+		 ipl_error_info error = {IPL_NO_ERROR, NULL, NULL});
+
 #endif /* __IPL_H__ */


### PR DESCRIPTION
Existing ipl_error_callback_func only supports bool type
parameter indicates ipl failure or not. SBE related ipl
failure requires additional info like type of failure
and additional log data to log SBE related failure handling.

Added new additional log data information structure data in the
exiting ipl_error_callback function to meet the error handling
requirements in BMC side. Setting new additional data as optional
parameter helps to reduce the existing ipl code impact.