### PR TITLE
libipl: ipl_error_callback_func prototype change

### DIFF
--- a/libipl/libipl.C
+++ b/libipl/libipl.C
@@ -353,9 +353,9 @@ void ipl_set_error_callback_func(ipl_error_callback_func_t fn)
 	g_ipl_error_callback_fn = fn;
 }
 
-void ipl_error_callback(bool status)
+void ipl_error_callback(const ipl_error_info& error)
 {
 	if (!g_ipl_error_callback_fn)
 		return;
-	g_ipl_error_callback_fn(status);
+	g_ipl_error_callback_fn(error);
 }

--- a/libipl/libipl.H
+++ b/libipl/libipl.H
@@ -1,6 +1,9 @@
 #ifndef __LIBIPL_H__
 #define __LIBIPL_H__
 
+#include <stdlib.h>
+#include <map>
+
 #define MAX_ISTEP	21
 
 enum ipl_mode {
@@ -18,11 +21,50 @@ enum ipl_type {
 #define IPL_INFO    1
 #define IPL_DEBUG   2
 
+//IPL Error types
+enum ipl_error_type {
+	IPL_ERR_NILL = 0,
+	IPL_ERR_HWP,
+	IPL_ERR_SBE_CHIPOP,
+	IPL_ERR_SBE_BOOT,
+	IPL_ERR_PRI_PROC_NON_FUNC,
+	IPL_ERR_FSI_TGT_NOT_FOUND,
+	IPL_ERR_CFAM,
+};
+
+typedef std::map<ipl_error_type, const char*> err_msg_map_type;
+const err_msg_map_type err_msg_map = {
+	{IPL_ERR_NILL, ""},
+	{IPL_ERR_HWP, "HWP execution reported error"},
+	{IPL_ERR_SBE_CHIPOP, "SBE chip-op reported error"},
+	{IPL_ERR_SBE_BOOT, "SBE Boot failure"},
+	{IPL_ERR_PRI_PROC_NON_FUNC, "Primary processor is non functional"},
+	{IPL_ERR_FSI_TGT_NOT_FOUND, "FSI target is not available"},
+	{IPL_ERR_CFAM, "CFAM read/write failure"},
+};
+
+// Error info structure.
+struct ipl_error_info {
+	enum ipl_error_type type;
+	//additional debug/callout data need to be included for cfam failures
+	void *private_data;
+	//specilized constructors
+	ipl_error_info() : type(IPL_ERR_NILL), private_data(NULL)  {}
+	ipl_error_info(ipl_error_type type) : type(type), private_data(NULL) {}
+
+	~ipl_error_info(){
+		// freeup the private_data allocated memory
+		if (private_data){
+			free(private_data);
+		}
+	}
+};
+
 extern "C" {
 #include <stdarg.h>
 
 typedef void (*ipl_log_func_t)(void *private_data, const char *fmt, va_list ap);
-typedef void (*ipl_error_callback_func_t)(bool status);
+typedef void (*ipl_error_callback_func_t)(const ipl_error_info& error);
 
 int ipl_init(enum ipl_mode mode);
 int ipl_run_major_minor(int major, int minor);

--- a/libipl/libipl_internal.H
+++ b/libipl/libipl_internal.H
@@ -25,5 +25,6 @@ void ipl_pre(void);
 void ipl_register(int major, struct ipl_step *steps, void (*pre_func)(void));
 enum ipl_mode ipl_mode(void);
 
-void ipl_error_callback(bool status);
+void ipl_error_callback(const ipl_error_info& error);
+
 #endif /* __IPL_H__ */

--- a/libipl/p10/common.C
+++ b/libipl/p10/common.C
@@ -54,7 +54,7 @@ int ipl_istep_via_sbe(int major, int minor)
 		if (!ipl_is_functional(proc)) {
 			ipl_log(IPL_ERROR, "Master processor (%d) is not functional\n",
 				pdbg_target_index(proc));
-			ipl_error_callback(false);
+			ipl_error_callback(IPL_ERR_PRI_PROC_NON_FUNC);
 			return 1;
 		}
 
@@ -70,7 +70,7 @@ int ipl_istep_via_sbe(int major, int minor)
 			rc = 0;
 		}
 
-		ipl_error_callback(rc == 0);
+		ipl_error_callback((rc == 0) ? IPL_ERR_NILL : IPL_ERR_HWP);
 		break;
 	}
 
@@ -96,7 +96,7 @@ int ipl_istep_via_hostboot(int major, int minor)
 		if (!ipl_is_functional(proc)) {
 			ipl_log(IPL_ERROR, "Master processor(%d) is not functional\n",
 				pdbg_target_index(proc));
-			ipl_error_callback(false);
+			ipl_error_callback(IPL_ERR_PRI_PROC_NON_FUNC);
 			return 1;
 		}
 
@@ -111,7 +111,7 @@ int ipl_istep_via_hostboot(int major, int minor)
 		else
 			rc = 0;
 
-		ipl_error_callback(rc == 0);
+		ipl_error_callback((rc == 0) ? IPL_ERR_NILL : IPL_ERR_HWP);
 		break;
 	}
 

--- a/libipl/p10/ipl_poweroff.C
+++ b/libipl/p10/ipl_poweroff.C
@@ -32,7 +32,7 @@ int ipl_pre_poweroff(void)
 			ipl_log(IPL_ERROR,
 				"p10_pre_poweroff failed for proc index %d\n",
 				pdbg_target_index(proc));
-			ipl_error_callback(false);
+			ipl_error_callback(IPL_ERR_HWP);
 
 			// Count num of failed proc to do pre-poweroff
 			++rc;


### PR DESCRIPTION
Updated ipl_error_callback_func protype to support better
error handling support for libipl users. Existing function
only supports bool type parameter. BMC requires additional
data to create error logs with additional debug information.

Added new structure, which includes the failure reason code
and and generic buffer , which will help for future use case
to share to share debug data, like callout, guard etc.
