### PR TITLE
libipl: fix sbe_start error handling issues.

### DIFF
--- a/libipl/p10/ipl0.C
+++ b/libipl/p10/ipl0.C
@@ -589,9 +589,12 @@ static int ipl_sbe_start(void)
 
 				fapirc = p10_start_cbs(proc, true);
 				if (fapirc == fapi2::FAPI2_RC_SUCCESS) {
-					if (!ipl_sbe_booted(proc, 1)) {
+					if (!ipl_sbe_booted(proc, 25)) {
 						ipl_log(IPL_ERROR, "SBE did not boot\n");
 						err_type = IPL_ERR_SBE_BOOT;
+					}
+					else {
+						rc = 0;
 					}
 				} else {
 					err_type = IPL_ERR_HWP;


### PR DESCRIPTION
 - Fixed missing return code value innitlisation in hwp
   success path
 - Fixed sbe timeout related typo introduced in recent
   merge.

Tested: BMC booted successfully with this commit