### PR TITLE
Add support for SBE dump collection

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -101,7 +101,8 @@ libphal_la_SOURCES = \
 	libphal/utils_pdbg.H \
 	libphal/libphal.H \
 	libphal/phal_sbe.C \
-	libphal/phal_pdbg.C
+	libphal/phal_pdbg.C \
+	libphal/phal_dump.C
 
 libphal_la_CXXFLAGS = -Wall -Werror $(EKB_CXXFLAGS) \
 	-I$(srcdir)/libphal

--- a/configure.ac
+++ b/configure.ac
@@ -50,7 +50,8 @@ EKB_CXXFLAGS=" \
 -I${INCDIR}/hwpf/fapi2/include/error_info \
 -I${INCDIR}/hwpf/fapi2/include/plat \
 -I${INCDIR}/ekb/hwpf/fapi2/include \
--I${INCDIR}/ekb/chips/${CHIP}/procedures/hwp/ffdc"
+-I${INCDIR}/ekb/chips/${CHIP}/procedures/hwp/ffdc \
+-I${INCDIR}/ekb/chips/${CHIP}/procedures/hwp/lib"
 AC_SUBST([EKB_CXXFLAGS])
 
 saved_LDFLAGS=$LDFLAGS

--- a/libphal/libphal.H
+++ b/libphal/libphal.H
@@ -6,6 +6,8 @@ extern "C" {
 #include <libpdbg.h>
 }
 
+#include <filesystem>
+
 namespace openpower::phal
 {
 namespace sbe
@@ -88,4 +90,19 @@ void init(pdbg_backend pdbgBackend = PDBG_BACKEND_SBEFIFO,
 	      "/var/lib/phosphor-software-manager/pnor/rw/DEVTREE");
 
 } // namespace pdbg
+
+namespace dump
+{
+/**
+ * @brief Execute HWPs to collect SBE dump
+ * @param[in] id Id of the dump
+ * @param[in] failingUnit Id of proc containing failing SBE
+ * @param[in] dumpPath Path to stored the dump files
+ *
+ * Exceptions: PDBG_INIT_FAIL for any pdbg init related failure.
+ */
+void collectSBEDump(uint32_t id, uint32_t failingUnit,
+		    const std::filesystem::path &dumpPath);
+
+} // namespace dump
 } // namespace openpower::phal

--- a/libphal/phal_dump.C
+++ b/libphal/phal_dump.C
@@ -1,0 +1,436 @@
+extern "C" {
+#include <libgen.h>
+#include <libpdbg.h>
+#include <libpdbg_sbe.h>
+#include <sys/stat.h>
+#include <unistd.h>
+}
+
+#include "libphal.H"
+#include "log.H"
+#include "phal_exception.H"
+#include "utils_pdbg.H"
+
+#include <fapi2.H>
+#include <ekb/hwpf/fapi2/include/return_code_defs.H>
+#include <ekb/chips/p10/procedures/hwp/lib/pibms_regs2dump.H>
+#include <ekb/chips/p10/procedures/hwp/lib/p10_pibmem_dump.H>
+#include <ekb/chips/p10/procedures/hwp/lib/p10_pibms_reg_dump.H>
+#include <ekb/chips/p10/procedures/hwp/lib/p10_ppe_state.H>
+#include <ekb/chips/p10/procedures/hwp/lib/p10_sbe_localreg_dump.H>
+#include <ekb/chips/p10/procedures/hwp/perv/p10_extract_sbe_rc.H>
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+namespace openpower::phal
+{
+namespace dump
+{
+
+using namespace openpower::phal::logging;
+using namespace openpower::phal::utils::pdbg;
+
+/* SBE register number and name for writing
+ * to the file */
+struct DumpSBEReg {
+	uint16_t number; // Register number
+	char name[32];	 // Register name
+} __attribute__((packed));
+
+/* SBE register details with value */
+struct DumpSBERegVal {
+	DumpSBEReg reg; // Register details
+	uint64_t value; // Value extracted
+
+	DumpSBERegVal(const uint16_t num, const std::string& nm,
+		      const uint64_t val)
+	{
+		reg.number = num;
+// Adding to avoid Wstringop-truncation warning
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-truncation"
+		strncpy(reg.name, nm.c_str(), 32);
+#pragma GCC diagnostic pop
+		value = val;
+	}
+} __attribute__((packed));
+
+/* PIBMEM register number, name and attribute for writing
+ * in to the file */
+struct DumpPIBMSReg {
+	uint64_t addr; // Register address
+	char name[32]; // Register name
+	uint32_t attr; // Attribute
+} __attribute__((packed));
+
+/* PIBMEM register detailes with value */
+struct DumpPIBMSRegVal {
+	DumpPIBMSReg reg; // Register details
+	uint64_t value;	  // Value extracted
+
+	DumpPIBMSRegVal(const uint64_t addrs, const std::string& nm,
+			const uint32_t attrib, const uint64_t val)
+	{
+		reg.addr = addrs;
+// Adding to avoid Wstringop-truncation warning
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-truncation"
+		strncpy(reg.name, nm.c_str(), 32);
+#pragma GCC diagnostic pop
+		reg.attr = attrib;
+		value = val;
+	}
+} __attribute__((packed));
+
+// PPE register details
+struct DumpPPERegValue {
+	uint16_t number;     // Register number
+	uint32_t value;	     // Extracted value
+	uint8_t reserved[8]; // Unused for padding
+
+	DumpPPERegValue(uint16_t num, uint32_t val)
+	{
+		number = num;
+		value = val;
+	}
+} __attribute__((packed));
+
+/**
+ * @brief Return the proc target corresponding to failing unit
+ * @param[in] failingUnit Position of the proc containing the failed SBE
+ *
+ * @return Pointer to the pdbg target for proc
+ *
+ * Exceptions: PDBG_TARGET_NOT_OPERATIONAL if target is not available
+ */
+struct pdbg_target* getProcFromFailingId(const uint32_t failingUnit)
+{
+	struct pdbg_target* proc = NULL;
+	struct pdbg_target* target;
+	pdbg_for_each_class_target("proc", target)
+	{
+		if (pdbg_target_index(target) != failingUnit) {
+			continue;
+		}
+
+		if (pdbg_target_probe(target) != PDBG_TARGET_ENABLED) {
+			break;
+		}
+		proc = target;
+	}
+	if (proc == NULL) {
+		log(level::ERROR,
+		    "No Proc target found to execute the dump for failing "
+		    "unit=%d",
+		    failingUnit);
+		throw sbeError_t(exception::PDBG_TARGET_NOT_OPERATIONAL);
+	}
+	return proc;
+}
+
+/**
+ * @brief Initialize the PDBG and SBE to start collection
+ * @param[in] failingUnit Position of the proc containing the failed SBE
+ *
+ * Exceptions: PDBG_INIT_FAIL for any pdbg init related failure.
+ *             PDBG_TARGET_NOT_OPERATIONAL for invalid failing unit
+ *             HWP_EXECUTION_FAILED if the extract rc procedure is failing
+ */
+struct pdbg_target* preCollection(const uint32_t failingUnit)
+{
+	// Initialize PDBG with KERNEL backend
+	pdbg::init(PDBG_BACKEND_KERNEL);
+
+	if (libekb_init()) {
+		log(level::ERROR, "libekb_init failed");
+		throw std::runtime_error("libekb initialization failed");
+	}
+
+	// FSI and PIB targets for executing HWP
+	struct pdbg_target *fsi, *pib;
+	char path[16];
+
+	// Find the proc target from the failing unit id
+	struct pdbg_target* proc = getProcFromFailingId(failingUnit);
+
+	// Probe FSI for HWP execution
+	sprintf(path, "/proc%d/fsi", pdbg_target_index(proc));
+	fsi = pdbg_target_from_path(NULL, path);
+	if (fsi == nullptr) {
+		log(level::ERROR, "Failed to get FSI target for(%s)",
+		    pdbg_target_path(proc));
+		throw dumpError_t(exception::PDBG_TARGET_NOT_OPERATIONAL);
+	}
+
+	// Probe PIB for HWP execution
+	sprintf(path, "/proc%d/pib", pdbg_target_index(proc));
+	pib = pdbg_target_from_path(NULL, path);
+	if (pib == nullptr) {
+		log(level::ERROR, "Failed to get PIB target for(%s)",
+		    pdbg_target_path(proc));
+		throw dumpError_t(exception::PDBG_TARGET_NOT_OPERATIONAL);
+	}
+
+	if ((pdbg_target_probe(fsi) != PDBG_TARGET_ENABLED ||
+	     pdbg_target_probe(pib) != PDBG_TARGET_ENABLED)) {
+		log(level::ERROR, "Failed to prob PIB or FSI");
+		throw dumpError_t(exception::PDBG_TARGET_NOT_OPERATIONAL);
+	}
+
+	// Execute SBE extract rc to set up sdb bit for pibmem dump to work
+	// TODO Add error handling or revisit procedure later
+	fapi2::ReturnCode fapiRc;
+	P10_EXTRACT_SBE_RC::RETURN_ACTION recovAction;
+
+	// p10_extract_sbe_rc is returning the error along with
+	// recovery action, so not checking the fapirc.
+	fapiRc = p10_extract_sbe_rc(proc, recovAction, true);
+	log(level::INFO,
+	    "p10_extract_sbe_rc for proc=%s returned rc=0x%08X and SBE "
+	    "Recovery Action=0x%08X",
+	    pdbg_target_path(proc), fapiRc, recovAction);
+	return proc;
+}
+
+/**
+ * @brief Write the dump file to the path
+ * @param[in] data Pointer to the data buffer
+ * @param[in] len Length of the buffer
+ * @param[in] dumpPath Path of the file
+ *
+ * Throws FILE_OPERATION_FAILED in the case of error
+ */
+void writeDumpFile(char* data, size_t len, std::filesystem::path& dumpPath)
+{
+	log(level::INFO, "writng dump data to file");
+	std::ofstream outfile{dumpPath, std::ios::out | std::ios::binary};
+	if (!outfile.good()) {
+		int err = errno;
+		log(level::ERROR,
+		    "Failed to open the dump file for writing err=%d", err);
+		throw dumpError_t(exception::FILE_OPERATION_FAILED);
+	}
+	outfile.exceptions(std::ifstream::failbit | std::ifstream::badbit |
+			   std::ifstream::eofbit);
+	try {
+		outfile.write(data, len);
+	} catch (const std::ofstream::failure& oe) {
+		int err = errno;
+		log(level::ERROR,
+		    "Failed to write to dump file err=%d error message=%s", err,
+		    oe.what());
+		throw dumpError_t(exception::FILE_OPERATION_FAILED);
+	}
+	outfile.close();
+}
+
+void collectSBEDump(uint32_t id, uint32_t failingUnit,
+		    const std::filesystem::path& dumpPath)
+{
+	log(level::INFO,
+	    "Collecting SBE dump: path=%s, id=%d, chip position=%d",
+	    dumpPath.string().c_str(), id, failingUnit);
+
+	std::stringstream ss;
+	ss << std::setw(8) << std::setfill('0') << id;
+
+	// Filename format
+	// <dumpID>.<nodeNUM>_<procNum>.Sbedata_p10_<HWP name>
+	std::string baseFilename =
+	    ss.str() + ".0_" + std::to_string(failingUnit) + "_SbeData_p10_";
+
+	// Execute pre-collection and get proc corresponding to failing unit
+	struct pdbg_target* proc = preCollection(failingUnit);
+
+	// Get pib for the proc
+	struct pdbg_target* pib = getPibTarget(proc);
+
+	// Set SBE state to SBE_STATE_DEBUG_MODE
+	if (0 > sbe_set_state(pib, SBE_STATE_DEBUG_MODE)) {
+		log(level::ERROR, "Setting SBE state to debug mode failed");
+		throw std::runtime_error(
+		    "Setting SBE state to debug mode failed");
+	}
+
+	fapi2::ReturnCode fapiRc;
+
+	try {
+		// Collect SBE local register dump
+		std::vector<SBESCOMRegValue_t> sbeScomRegValue;
+		fapiRc = p10_sbe_localreg_dump(proc, true, sbeScomRegValue);
+		if (fapiRc != fapi2::FAPI2_RC_SUCCESS) {
+			log(level::ERROR,
+			    "Failed in p10_sbe_localreg_dump for proc=%s, "
+			    "rc=0x%08X",
+			    pdbg_target_path(proc), fapiRc);
+		} else {
+			std::vector<DumpSBERegVal> dumpRegs;
+			for (auto& reg : sbeScomRegValue) {
+				dumpRegs.emplace_back(reg.reg.number,
+						      reg.reg.name, reg.value);
+			}
+			std::string dumpFilename =
+			    baseFilename + "p10_sbe_localreg_dump";
+			std::filesystem::path basePath =
+			    dumpPath / dumpFilename;
+
+			try {
+				writeDumpFile(
+				    reinterpret_cast<char*>(&dumpRegs[0]),
+				    sizeof(DumpSBERegVal) * dumpRegs.size(),
+				    basePath);
+			} catch (const dumpError_t& e) {
+				log(level::ERROR,
+				    "Error in writing p10_sbe_localreg_dump "
+				    "file "
+				    "errorMsg=%s",
+				    e.what());
+				throw;
+			}
+		}
+
+		// Dump contents of various PIB Masters and Slaves internal
+		// registers
+		std::vector<sRegV> pibmsRegSet;
+		for (auto& reg : pibms_regs_2dump) {
+			sRegV regv;
+			regv.reg = reg;
+			pibmsRegSet.emplace_back(regv);
+		}
+
+		fapiRc = p10_pibms_reg_dump(proc, pibmsRegSet);
+		if (fapiRc != fapi2::FAPI2_RC_SUCCESS) {
+			log(level::ERROR,
+			    "Failed in p10_pibms_reg_dump for proc=%s, "
+			    "rc=0x%08X",
+			    pdbg_target_path(proc), fapiRc);
+		} else {
+			std::vector<DumpPIBMSRegVal> dumpRegs;
+			for (sRegV& regs : pibmsRegSet) {
+				dumpRegs.emplace_back(
+				    regs.reg.addr, regs.reg.name, regs.reg.attr,
+				    regs.value);
+			}
+			std::string dumpFilename =
+			    baseFilename + "p10_pibms_reg_dump";
+			std::filesystem::path basePath =
+			    dumpPath / dumpFilename;
+			try {
+				writeDumpFile(
+				    reinterpret_cast<char*>(&dumpRegs[0]),
+				    sizeof(DumpPIBMSRegVal) * dumpRegs.size(),
+				    basePath);
+			} catch (const dumpError_t& e) {
+				log(level::ERROR,
+				    "Error in writing p10_pibms_reg_dump file, "
+				    "errorMsg=%s",
+				    e.what());
+				throw;
+			}
+		}
+
+		// Dump the PIBMEM Array based on starting and number of address
+		std::vector<array_data_t> pibmemContents;
+		bool eccEnable = false;
+		uint32_t pibmemDumpStartByte = 0;
+		// Number of bytes to be read from PIBMEM
+		static constexpr uint32_t pibmemDumpNumOfByte = 0x7D400;
+		user_options userOptions = INTERMEDIATE_TILL_INTERMEDIATE;
+
+		fapiRc = p10_pibmem_dump(proc, pibmemDumpStartByte,
+					 pibmemDumpNumOfByte, userOptions,
+					 pibmemContents, eccEnable);
+		if (fapiRc != fapi2::FAPI2_RC_SUCCESS) {
+			log(level::ERROR,
+			    "Failed in p10_pibmem_dump for proc=%s, rc=0x%08X",
+			    pdbg_target_path(proc), fapiRc);
+		} else {
+			std::vector<uint64_t> dumpData;
+			for (auto& data : pibmemContents) {
+				dumpData.push_back(data.read_data);
+			}
+			std::string dumpFilename =
+			    baseFilename + "p10_pibmem_dump";
+			std::filesystem::path basePath =
+			    dumpPath / dumpFilename;
+			try {
+				writeDumpFile(
+				    reinterpret_cast<char*>(&dumpData[0]),
+				    sizeof(uint64_t) * dumpData.size(),
+				    basePath);
+			} catch (const dumpError_t& e) {
+				log(level::ERROR,
+				    "Error in writing p10_pibmem_dump file "
+				    "errorMsg=%s",
+				    e.what());
+				throw;
+			}
+		}
+
+		// Dump the PPE state based on the based base address
+		PPE_DUMP_MODE mode = SNAPSHOT;
+		uint32_t instanceNum = 0;
+		std::vector<Reg32Value_t> ppeGprsValue;
+		std::vector<Reg32Value_t> ppeSprsValue;
+		std::vector<Reg32Value_t> ppeXirsValue;
+		PPE_TYPES type = PPE_TYPE_SBE;
+
+		fapiRc =
+		    p10_ppe_state(proc, type, instanceNum, mode, ppeGprsValue,
+				  ppeSprsValue, ppeXirsValue);
+		if (fapiRc != fapi2::FAPI2_RC_SUCCESS) {
+			log(level::ERROR,
+			    "Failed in p10_ppe_state for proc=%s, rc=0x%08X",
+			    pdbg_target_path(proc), fapiRc);
+		} else {
+			std::vector<DumpPPERegValue> ppeState;
+			for (auto& gpr : ppeGprsValue) {
+				ppeState.emplace_back(gpr.number, gpr.value);
+			}
+			for (auto& spr : ppeSprsValue) {
+				ppeState.emplace_back(spr.number, spr.value);
+			}
+			for (auto& xir : ppeXirsValue) {
+				ppeState.emplace_back(xir.number, xir.value);
+			}
+
+			std::string dumpFilename =
+			    baseFilename + "p10_ppe_state";
+			std::filesystem::path basePath =
+			    dumpPath / dumpFilename;
+			try {
+				writeDumpFile(
+				    reinterpret_cast<char*>(&ppeState[0]),
+				    sizeof(DumpPPERegValue) * ppeState.size(),
+				    basePath);
+			} catch (const dumpError_t& e) {
+				log(level::ERROR,
+				    "Error in writing p10_ppe_state file, "
+				    "errorMsg=%s",
+				    e.what());
+				throw;
+			}
+		}
+	} catch (const std::exception& e) {
+		log(level::ERROR, "Failed to collect the SBE dump");
+		if (0 > sbe_set_state(pib, SBE_STATE_FAILED)) {
+			log(level::ERROR, "Failed to set SBE state to FAILED");
+		}
+		// Dump collection failed remove the directory
+		// and partial contents
+		std::filesystem::remove_all(dumpPath);
+		// Rethrow the exception
+		throw;
+	}
+
+	// Set SBE state to SBE_STATE_FAILED
+	if (0 > sbe_set_state(pib, SBE_STATE_FAILED)) {
+		log(level::ERROR, "Failed to set SBE state to FAILED");
+	}
+	log(level::INFO, "SBE dump collected");
+}
+} // namespace dump
+} // namespace openpower::phal

--- a/libphal/phal_exception.H
+++ b/libphal/phal_exception.H
@@ -20,6 +20,8 @@ enum ERR_TYPE {
 	SBE_CMD_TIMEOUT,
 	SBE_FFDC_NO_DATA,
 	PDBG_INIT_FAIL,
+	HWP_EXECUTION_FAILED,
+	FILE_OPERATION_FAILED,
 };
 
 // Error type to message map.
@@ -33,7 +35,9 @@ const errMsgMapType errMsgMap = {
     {SBE_CMD_FAILED, "SBE command reported error"},
     {SBE_CMD_TIMEOUT, "SBE command timeout"},
     {SBE_FFDC_NO_DATA, "SBE FFDC No failure data"},
-    {PDBG_INIT_FAIL, "PDBG initialisation failed"}};
+    {PDBG_INIT_FAIL, "PDBG initialisation failed"},
+    {HWP_EXECUTION_FAILED, "HWP execution failed"},
+    {FILE_OPERATION_FAILED, "File operation failed"}};
 
 // phal specific errors base exception class
 struct phalError : public std::exception {
@@ -104,9 +108,43 @@ class SbeError final : public phalError
 	std::string fileName;
 };
 
+// Exception handling for dump specific functions
+class DumpError final : public phalError
+{
+       public:
+	DumpError(ERR_TYPE type) : type(type)
+	{
+	}
+
+	DumpError &operator=(DumpError &&) = default;
+	DumpError(DumpError &&) = default;
+
+	/* return error type */
+	ERR_TYPE errType() const noexcept override
+	{
+		return type;
+	}
+
+	/* return error string */
+	const char *what() const noexcept override
+	{
+		auto msg = "UNSUPPORTED_ERROR_TYPE";
+		auto errMsg = errMsgMap.find(type);
+		if (errMsg != errMsgMap.end()) {
+			msg = errMsg->second;
+		}
+		return msg;
+	}
+
+       private:
+	/* Error type */
+	ERR_TYPE type;
+};
+
 } // namespace exception
 
 using phalError_t = openpower::phal::exception::phalError;
 using sbeError_t = openpower::phal::exception::SbeError;
+using dumpError_t = openpower::phal::exception::DumpError;
 
 } // namespace openpower::phal


### PR DESCRIPTION
Self Boot Engine(SBE) dump is collected from the non-
responsive SBE by executing four hardware procedures.
The output of each hardware procedure is written to
files in the path provided.

**Tests:**
**Create dump:**
```
busctl --verbose call org.open_power.Dump.Manager  /org/openpower/dump xyz.openbmc_project.Dump.Create CreateDump a{sv} 3 "com.ibm.Dump.Create.CreateParameters.DumpType" s "com.ibm.Dump.Create.DumpType.SBE" "com.ibm.Dump.Create.CreateParameters.ErrorLogId" t 0xDEADBEEF "com.ibm.Dump.Create.CreateParameters.FailingUnitId" t 0
MESSAGE "o" {
        OBJECT_PATH "/xyz/openbmc_project/dump/sbe/entry/16";
};
```

**dump collection:**
```
Oct 11 05:20:22 rain98bmc phosphor-dump-manager[430]: OpenPOWER dumps are enabled
Oct 11 05:20:23 rain98bmc openpower-dump-manager[1908]: Collecting SBE dump: path=/tmp/openpower-dumps/sbe/16/plat_dump, id=16, chip position=0
Oct 11 05:20:23 rain98bmc openpower-dump-manager[1908]: PDBG Initilization started
Oct 11 05:20:23 rain98bmc openpower-dump-manager[1908]: err: p10_extract_sbe_rc:478 p10_extract_sbe_rc : The external halt_req input was active.
Oct 11 05:20:23 rain98bmc openpower-dump-manager[1908]: err: p10_extract_sbe_rc:769 p10_extract_sbe_rc : Data machine check - precise store for EDR = FFFCBCA8
Oct 11 05:20:23 rain98bmc openpower-dump-manager[1908]: err: p10_extract_sbe_rc:1771 Halted due to unknown error at IAR location FFF80014
Oct 11 05:20:23 rain98bmc openpower-dump-manager[1908]: err: EXTRACT_SBE_RC_UNKNOWN_ERROR:8154 Unknown error has occured, try bkup seeproms or debug has to be done to understand the error Action: Switch sides or debug[REIPL_BKP_BMSEEPROM]
Oct 11 05:20:23 rain98bmc openpower-dump-manager[1908]: err: _setHwpError:120 _setHwpError: Creating HWP error 0xb4a5c5
Oct 11 05:20:23 rain98bmc openpower-dump-manager[1908]: err: p10_extract_sbe_rc:1774 SBE halted due to unknown error
Oct 11 05:20:23 rain98bmc openpower-dump-manager[1908]: p10_extract_sbe_rc for proc=/proc0 returned rc=0x7E892FC4 and SBE Recovery Action=0x00000009
Oct 11 05:20:23 rain98bmc openpower-dump-manager[1908]: writng dump data to file
Oct 11 05:20:23 rain98bmc openpower-dump-manager[1908]: writng dump data to file
Oct 11 05:20:23 rain98bmc openpower-dump-manager[1908]: writng dump data to file
Oct 11 05:20:23 rain98bmc openpower-dump-manager[1908]: writng dump data to file
Oct 11 05:20:23 rain98bmc openpower-dump-manager[1908]: SBE dump collected
Oct 11 05:20:23 rain98bmc openpower-dump-manager[1906]: Dump collected, initiating packaging
Oct 11 05:20:24 rain98bmc phosphor-dump-manager[1915]: plat_dump/00000016.0_0_SbeData_p10_p10_pibmem_dump
Oct 11 05:20:24 rain98bmc phosphor-dump-manager[1915]: plat_dump/00000016.0_0_SbeData_p10_p10_pibms_reg_dump
Oct 11 05:20:24 rain98bmc phosphor-dump-manager[1915]: plat_dump/00000016.0_0_SbeData_p10_p10_ppe_state
Oct 11 05:20:24 rain98bmc phosphor-dump-manager[1915]: plat_dump/00000016.0_0_SbeData_p10_p10_sbe_localreg_dump
Oct 11 05:20:24 rain98bmc phosphor-dump-manager[1909]: Adding Dump Header :/usr/share/dreport.d/include.d/gendumpheader
Oct 11 05:20:24 rain98bmc phosphor-dump-manager[1909]: Mon Oct 11 05:20:24 UTC 2021 Successfully completed

```

**Dump Extraction**

```
-bash-4.2$ python sbe-debug.py -e sbedump_16_1633929623.tar.gz
Extract dump File
gunzip on file: sbedump_16_1633929623.tar.gz
Parsing the Dump header
Missing section indicator is 0x0
Dump Content Type is 0x0
Sys data size is 0x0
HW data size is 0x27f31
Length of tar is 0x27f31
Command is dd skip=1232 count=163633 if=sbedump_16_1633929623.tar of=output.binary bs=1
163633+0 records in
163633+0 records out
163633 bytes (164 kB) copied, 0.399401 s, 410 kB/s
Command is tar -xvf output.binary
plat_dump/00000016.0_0_SbeData_p10_p10_pibmem_dump
plat_dump/00000016.0_0_SbeData_p10_p10_pibms_reg_dump
plat_dump/00000016.0_0_SbeData_p10_p10_ppe_state
plat_dump/00000016.0_0_SbeData_p10_p10_sbe_localreg_dump
-bash-4.2$ python sbe-debug.py -t FILE -f plat_dump/00000016.0_0_SbeData_p10_p10_sbe_localreg_dump -l  sbelocalregister
ERROR: file sbe_DD1.syms not found
Symbol file not found, limited commands avaliable
File path:  plat_dump/00000016.0_0_SbeData_p10_p10_sbe_localreg_dump
********************************************************************
Reg Number  Reg Value            Reg String
0020        0000ffffffff0000     SBE_MISC
0000        000000000000c006     SBE_EISR
2000        000000000000c0d8     SBE_EIMR
4000        00000000000030ff     SBE_EIPR
6000        00000000000000c0     SBE_EITR
8000        0000000000000006     SBE_EISTR
a000        0000000000000006     SBE_EINR
0001        0000000000000000     SBE_TSEL
2001        0000000000000000     SBE_DBG
4001        0000000041a9f99b     SBE_TBR
6001        000000000000f8ff     SBE_IVPR
4020        ca08007016017103     SBE_LFR
```


Signed-off-by: Dhruvaraj Subhashchandran <dhruvaraj@in.ibm.com>