### PR TITLE
libphal: fix validateSBEState function build issue

### DIFF
--- a/libphal/libphal.H
+++ b/libphal/libphal.H
@@ -23,7 +23,7 @@ namespace sbe
  *
  * Exceptions: SbeError
  */
-void validateSBEState(const struct pdbg_target *proc);
+void validateSBEState(struct pdbg_target *proc);
 
 /**
  * @brief utility function to set SBE State


### PR DESCRIPTION
Added fix related to  undefined reference to
validateSBEState(pdbg_target const*)'by removing
input parameter type "const" from libphal.H
