### PR TITLE
Fix the PPE Register structure.

### DIFF
--- a/libphal/phal_dump.C
+++ b/libphal/phal_dump.C
@@ -89,7 +89,7 @@ struct DumpPIBMSRegVal {
 struct DumpPPERegValue {
 	uint16_t number;     // Register number
 	uint32_t value;	     // Extracted value
-	uint8_t reserved[8]; // Unused for padding
+	char* name;          // Name of the register(Unused)
 
 	DumpPPERegValue(uint16_t num, uint32_t val)
 	{


### PR DESCRIPTION
The PPE register is expecting a char* which was not added
and that caused the parser to fail the SBE dump data
properly.

Signed-off-by: Dhruvaraj Subhashchandran <dhruvaraj@in.ibm.com>