### PR TITLE
Add handling for platform function errors

### DIFF
--- a/libipl/libipl.H
+++ b/libipl/libipl.H
@@ -31,6 +31,8 @@ enum ipl_error_type {
 	IPL_ERR_FSI_TGT_NOT_FOUND,
 	IPL_ERR_FSI_REG,
 	IPL_ERR_PIB_TGT_NOT_FOUND,
+	IPL_ERR_PLAT,
+	IPL_ERR_ATTR_READ_FAIL
 };
 
 typedef std::map<ipl_error_type, const char*> err_msg_map_type;
@@ -43,22 +45,21 @@ const err_msg_map_type err_msg_map = {
 	{ IPL_ERR_FSI_TGT_NOT_FOUND, "FSI target is not available" },
 	{ IPL_ERR_FSI_REG, "FSI register read/write failure" },
 	{ IPL_ERR_PIB_TGT_NOT_FOUND, "PIB target is not available" },
+	{ IPL_ERR_PLAT, "PLAT execution reported error" },
+	{ IPL_ERR_ATTR_READ_FAIL, "Device tree attribute read failure" },
 };
 
 // Error info structure.
 struct ipl_error_info {
 	enum ipl_error_type type;
-	//additional debug/callout data need to be included for cfam failures
+	// caller need to clear the memory allocated
 	void *private_data;
 	//specilized constructors
 	ipl_error_info() : type(IPL_ERR_OK), private_data(NULL)  {}
 	ipl_error_info(ipl_error_type type) : type(type), private_data(NULL) {}
-
-	~ipl_error_info(){
-		// freeup the private_data allocated memory
-		if (private_data)
-			free(private_data);
-	}
+	ipl_error_info(ipl_error_type type, void* private_data) : type(type),
+		private_data(private_data) {}
+	~ipl_error_info(){}
 };
 
 extern "C" {

--- a/libipl/p10/common.H
+++ b/libipl/p10/common.H
@@ -7,6 +7,8 @@ extern "C" {
 #include <libpdbg_sbe.h>
 }
 
+#include <ekb/hwpf/fapi2/include/return_code.H>
+
 bool ipl_is_master_proc(struct pdbg_target *proc);
 int ipl_istep_via_sbe(int major, int minor);
 int ipl_istep_via_hostboot(int major, int minor);
@@ -89,4 +91,14 @@ int ipl_set_sbe_state_all(enum sbe_state state);
  */
 int ipl_set_sbe_state_all_sec(enum sbe_state state);
 
+
+/*
+ * @brief Process HWP/PLAT error to add callout/deconfig and callback
+ * details
+ * @param fapirc[in] - FAPI return code
+ * @param target[in] - target pointer
+ * @param deconfig[in] - true deconfig the target
+ */
+void ipl_process_fapi_error(const fapi2::ReturnCode& fapirc,
+	struct pdbg_target *target, bool deconfig=true);
 #endif /* __LIBIPL_P10_COMMON_H__ */

--- a/libipl/p10/ipl0.C
+++ b/libipl/p10/ipl0.C
@@ -394,12 +394,12 @@ static int ipl_set_ref_clock(void)
 			pdbg_target_index(proc));
 		fapirc = p10_setup_ref_clock(proc);
 		if (fapirc != fapi2::FAPI2_RC_SUCCESS) {
-			ipl_log(IPL_ERROR, "Istep set_ref_clock failed on chip %d, rc=%d\n",
-                                pdbg_target_index(proc), fapirc);
+			ipl_log(IPL_ERROR, "Istep set_ref_clock failed on chip %s, rc=%d \n",
+				pdbg_target_path(proc), fapirc);
 			rc++;
 		}
 
-		ipl_error_callback((fapirc == fapi2::FAPI2_RC_SUCCESS) ? IPL_ERR_OK : IPL_ERR_HWP);
+		ipl_process_fapi_error(fapirc, proc);
 	}
 
 	if (!ipl_check_functional_master()){
@@ -435,13 +435,13 @@ static int ipl_proc_clock_test(void)
 			rc++;
 		}
 
-		ipl_error_callback((fapirc == fapi2::FAPI2_RC_SUCCESS) ? IPL_ERR_OK : IPL_ERR_HWP);
+		ipl_process_fapi_error(fapirc, proc);
 	}
 
 	if (!ipl_check_functional_master()){
 		ipl_error_callback(IPL_ERR_PRI_PROC_NON_FUNC);
 		return 1;
-        }
+    }
 
 	return rc;
 }
@@ -480,9 +480,9 @@ static int ipl_proc_select_boot_prom(void)
 		if (fapirc == fapi2::FAPI2_RC_SUCCESS)
 			rc = 0;
 
-		ipl_error_callback((fapirc == fapi2::FAPI2_RC_SUCCESS) ? IPL_ERR_OK : IPL_ERR_HWP);
+		ipl_process_fapi_error(fapirc, proc);
 		break;
-        }
+    }
 
 	if (!ipl_check_functional_master()) {
 		ipl_error_callback(IPL_ERR_PRI_PROC_NON_FUNC);
@@ -582,7 +582,7 @@ static int ipl_sbe_config_update(void)
 		if (fapirc == fapi2::FAPI2_RC_SUCCESS)
 			rc = 0;
 
-		ipl_error_callback((fapirc == fapi2::FAPI2_RC_SUCCESS) ? IPL_ERR_OK : IPL_ERR_HWP);
+		ipl_process_fapi_error(fapirc, proc);
 		break;
 	}
 
@@ -614,7 +614,7 @@ static int ipl_sbe_start(void)
 			if (fapirc != fapi2::FAPI2_RC_SUCCESS)
 				ret++;
 
-			ipl_error_callback((fapirc == fapi2::FAPI2_RC_SUCCESS) ? IPL_ERR_OK : IPL_ERR_HWP);
+			ipl_process_fapi_error(fapirc, proc);
 			rc = ret;
 			continue;
 		}

--- a/libipl/p10/ipl_poweroff.C
+++ b/libipl/p10/ipl_poweroff.C
@@ -32,8 +32,7 @@ int ipl_pre_poweroff(void)
 			ipl_log(IPL_ERROR,
 				"p10_pre_poweroff failed for proc index %d\n",
 				pdbg_target_index(proc));
-			ipl_error_callback(IPL_ERR_HWP);
-
+			ipl_process_fapi_error(fapi_rc, proc, false);
 			// Count num of failed proc to do pre-poweroff
 			++rc;
 		}


### PR DESCRIPTION
1) At present platform errors are treated as normal ipl errors
and no callout details are added.

2) Modified to add callout info to the FFDC object when there
is error in plat code.

Tested:
    "Callout Section": {
        "Callout Count":        "1",
        "Callouts": [{
            "FRU Type":         "Normal Hardware FRU",
            "Priority":         "Medium Priority",
            "Location Code":    "U78DA.ND0.WZS0066-P0-C15",
            "Part Number":      "F210110",
            "CCIN":             "AB42",
            "Serial Number":    "YA3936061850",
            "MRU Id":           "00010000"
        }]
    }
    "User Data 1": {
    "Section Version": "1",
    "Sub-section type": "1",
    "Created by": "0x2000",
    "HWP_HW_CO_01_CLK_POS": "255",
    "HWP_HW_CO_01_HW_ID": "PROC_REF_CLOCK",
    "HWP_HW_CO_01_LOC_CODE": "Ufcs-P0-C15",
    "HWP_HW_CO_01_PHYS_PATH": "physical:sys-0/node-0/proc-0",
    "HWP_HW_CO_01_PRIORITY": "MEDIUM",
    "HWP_RC": "33554433",
    "HWP_RC_DESC": "Error in executing platform function",
    }

Signed-off-by: Marri Devender Rao <devenrao@in.ibm.com>
Change-Id: If740cdd2136bafec14d0499557fb923acf95f900