### PR TITLE
libphal: threadStopProc API support

### DIFF
--- a/libphal/libphal.H
+++ b/libphal/libphal.H
@@ -141,6 +141,16 @@ void getTiInfo(struct pdbg_target *proc, uint8_t **data, uint32_t *dataLen);
 void getDump(struct pdbg_target *proc, const uint8_t type, const uint8_t clock,
 	     const uint8_t faCollect, uint8_t **data, uint32_t *dataLen);
 
+/**
+ * @brief Execute stop all instructions on processor.
+ *
+ * @param[in] proc processor target to operate on
+ *
+ * Exceptions: SbeError with failure reason code, file name and fd.
+ *             std::runtime_error - for file operation failure.
+ */
+void threadStopProc(struct pdbg_target *proc);
+
 } // namespace sbe
 
 namespace pdbg

--- a/libphal/phal_exception.H
+++ b/libphal/phal_exception.H
@@ -40,7 +40,7 @@ const errMsgMapType errMsgMap = {
     {PDBG_TARGET_NOT_OPERATIONAL, "PDBG target not in operational state"},
     {PDBG_TARGET_NOT_FOUND, "PDBG target not found"},
     {PDBG_TARGET_PARENT_NOT_FOUND, "PDBG parent target not found"},
-    {PDBG_TARGET_NOT_FOUND, "PDBG target is invalid"},
+    {PDBG_TARGET_INVALID, "PDBG target is invalid"},
     {SBE_STATE_READ_FAIL, "FAILED to read SBE state"},
     {SBE_STATE_READ_FAIL, "FAILED to write SBE state"},
     {SBE_CHIPOP_NOT_ALLOWED, "SBE chip-op not allowed"},

--- a/libphal/phal_sbe.C
+++ b/libphal/phal_sbe.C
@@ -221,5 +221,24 @@ void getDump(struct pdbg_target *proc, const uint8_t type, const uint8_t clock,
 	}
 }
 
+void threadStopProc(struct pdbg_target *proc)
+{
+	validateProcTgt(proc);
+
+	log(level::INFO, "Enter: threadStopProc(%s)", pdbg_target_path(proc));
+
+	// validate SBE state
+	validateSBEState(proc);
+
+	// get PIB target
+	struct pdbg_target *pib = getPibTarget(proc);
+
+	// call pdbg back-end function
+	auto ret = thread_stop_proc(pib);
+	if (ret != 0) {
+		throw captureFFDC(proc);
+	}
+}
+
 } // namespace sbe
 } // namespace openpower::phal

--- a/libphal/utils_pdbg.C
+++ b/libphal/utils_pdbg.C
@@ -128,5 +128,21 @@ struct pdbg_target *getTgtFromBinPath(const ATTR_PHYS_BIN_PATH_Type &binPath)
 	return targetInfo.target;
 }
 
+void validateProcTgt(struct pdbg_target *tgt)
+{
+	const char *tgtClass = pdbg_target_class_name(tgt);
+	if (!tgtClass) {
+		log(level::ERROR,
+		    "validateProcTgt: pdbg_target_class_name returns "
+		    "empty class name");
+		throw pdbgError_t(exception::PDBG_TARGET_INVALID);
+	}
+	if (strcmp("proc", tgtClass)) {
+		log(level::ERROR,
+		    "validateProcTgt: Target is not processor type");
+		throw pdbgError_t(exception::PDBG_TARGET_INVALID);
+	}
+}
+
 } // namespace pdbg
 } // namespace openpower::phal::utils

--- a/libphal/utils_pdbg.H
+++ b/libphal/utils_pdbg.H
@@ -42,5 +42,14 @@ struct pdbg_target *getFsiTarget(struct pdbg_target *proc);
  **/
 struct pdbg_target *getTgtFromBinPath(const ATTR_PHYS_BIN_PATH_Type &binPath);
 
+/**
+ *  @brief  Helper function to validate the input target is processor type
+ *
+ *  @param[in]  tgt - target to check
+ *
+ *  Exceptions: PdbgError for non processor or invalid targets
+ */
+void validateProcTgt(struct pdbg_target *tgt);
+
 } // namespace pdbg
 } // namespace openpower::phal::utils


### PR DESCRIPTION
Added API to call sbe chip-op for stopping all threads
instruction on the processor.