### PR TITLE
libipl: Adding function to check FCO override bit

### DIFF
--- a/libipl/p10/ipl0.C
+++ b/libipl/p10/ipl0.C
@@ -50,6 +50,8 @@ extern "C" {
 #define GUARD_TGT_NOT_FOUND 2
 #define GUARD_PRIMARY_PROC_NOT_APPLIED 3
 
+constexpr auto BOOTTIME_GUARD_INDICATOR = "/tmp/phal/boottime_guard_indicator";
+
 struct guard_target {
   	uint8_t path[21];
 	bool set_hwas_state;
@@ -258,7 +260,6 @@ static bool guard_action_allowed()
     }
 
     namespace fs = std::filesystem;
-    constexpr auto BOOTTIME_GUARD_INDICATOR = "/tmp/phal/boottime_guard_indicator";
     fs::path boottime_guard_indicator(BOOTTIME_GUARD_INDICATOR);
 
     if (fs::exists(boottime_guard_indicator)) {
@@ -355,7 +356,6 @@ static void apply_fco_override(void)
 {
 	std::array<const char*, 8> mProcChild =
 		{"core", "pauc", "pau", "iohs", "mc", "chiplet", "pec", "fc"};
-
 	struct pdbg_target *proc, *child;
 	uint8_t buf[5];
 
@@ -547,6 +547,9 @@ static int ipl_updatehwmodel(void)
 		boot_file_absent = true;
 	  	std::ofstream file(GENESIS_BOOT_FILE);
 	}
+
+	if((ipl_type() == IPL_TYPE_MPIPL) || (!fs::exists(BOOTTIME_GUARD_INDICATOR)))
+		apply_fco_override();
 
 	process_guard_records();
 


### PR DESCRIPTION
Change:
-Adding new function update_master_proc_fco_state, which will
check the FCO bit of master proc children, if that is set,
will mark the functional state of that child as set.

Tested:
Setting the FCO bit i.e. 10000100
attributes write p10.c:k0:n0:s0:p00:c1 ATTR_HWAS_STATE 0x00000000 0x84

After istep 0, can see the value is changed to 0xe4
attributes read p10.c:k0:n0:s0:p00:c1 ATTR_HWAS_STATE
ATTR_HWAS_STATE: complex  = 0x00000000 0xe4

Signed-off-by: Chirag Sharma <chirshar@in.ibm.com>