### PR TITLE
libipl: sbe_config_update enable sbe chip-op failure data

### DIFF
--- a/libipl/p10/ipl0.C
+++ b/libipl/p10/ipl0.C
@@ -902,6 +902,10 @@ static int ipl_sbe_config_update(void)
 		return 1;
 	}
 
+	// Bit 4 and 5 Enable SBE FFDC collection.
+	boot_flags.setBit(4);
+	boot_flags.setBit(5);
+
 	// Bit 6 – disable security. 0b1 indicates disable the security
 	if (disable_security)
 		boot_flags.setBit(6);


### PR DESCRIPTION
Updated ATTR_BOOT_FLAGS to enable sbe chip-op failure
data collection by setting bit 4 and 5. Refer mailbox scratch 3
register definition for more details.

Tested: verified in istep mode running up to sbe_config_update
root@xxxx:/tmp# attributes export | grep BOOT_FLAGS
ATTR_BOOT_FLAGS    u32    0x8c000000
root@xxxx:/tmp# getcfam pu 283a
pu	k0:n0:s0:p00       0x8C000000
/usr/bin/edbg getcfam pu 283a
