### PR TITLE
libphal: deconfigureTgt skip primary processor deconfig

### DIFF
--- a/libphal/phal_pdbg.C
+++ b/libphal/phal_pdbg.C
@@ -108,6 +108,14 @@ void deconfigureTgt(const ATTR_PHYS_BIN_PATH_Type &physBinPath,
 		throw pdbgError_t(exception::PDBG_TARGET_NOT_FOUND);
 	}
 
+	if (isPrimaryProc(target)) {
+		log(level::WARNING,
+		    "deconfigureTgt: Skipping primary proc((%s)) deconfig by "
+		    "policy",
+		    pdbg_target_path(target));
+		return;
+	}
+
 	ATTR_HWAS_STATE_Type hwasState;
 	if (DT_GET_PROP(ATTR_HWAS_STATE, target, hwasState)) {
 		log(level::ERROR, "Could not read(%s) HWAS_STATE attribute",


### PR DESCRIPTION
Implemented policy to not allow primary processor deconfig
action to attempt best for primary processor failure during
boot process

Tested: verified deconfig records during primary processor failure