### PR TITLE
libphal: Add sbe halt state handling for threadStopProc chipop

### DIFF
--- a/libphal/phal_sbe.C
+++ b/libphal/phal_sbe.C
@@ -325,6 +325,9 @@ void threadStopProc(struct pdbg_target *proc)
 
 	log(level::INFO, "Enter: threadStopProc(%s)", pdbg_target_path(proc));
 
+	// SBE halt state need recovery before thread stop all chip-ops
+	sbeHaltStateRecovery(proc);
+
 	// validate SBE state
 	validateSBEState(proc);
 


### PR DESCRIPTION
Sbe stop instruction chip-op is reporting error during sbe halt state.
based on sbe  design direction in the power-off/error recovery path
If the secondary SBE is in halt state, issue sbe  hreset to get sbe
operational state to run chipop.

Tested: verified in driver verification test