### PR TITLE
configure: add include path to find p10_sbe_ext_defs header file

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -58,7 +58,9 @@ EKB_CXXFLAGS=" \
 -I${INCDIR}/hwpf/fapi2/include/plat \
 -I${INCDIR}/ekb/hwpf/fapi2/include \
 -I${INCDIR}/ekb/chips/${CHIP}/procedures/hwp/ffdc \
--I${INCDIR}/ekb/chips/${CHIP}/procedures/hwp/lib"
+-I${INCDIR}/ekb/chips/${CHIP}/procedures/hwp/lib \
+-I${INCDIR}/ekb/chips/${CHIP}/procedures/hwp/sbe" 
+
 AC_SUBST([EKB_CXXFLAGS])
 
 saved_LDFLAGS=$LDFLAGS


### PR DESCRIPTION
There are changes to p10_extract_sbe_rc.C which when picked by bumping ekb version is failing IPL build.

Below error noticed as the path to p10_sbe_ext_defs.H is not part of the include paths when building libphal.

In file included from ../git/libphal/phal_dump.C:21: /home/fspcibld/openbmc-dev-jenkins/workspace/OpenBMC-Dev/build/github-private/openbmc-build-matrix/label/builder/target/p10bmc/build/work/armv7ahf-vfpv4d16-openbmc-linux-gnueabi/ipl/1.0+gitAUTOINC+2ad99ec69d-r1/recipe-sysroot/usr/include/ekb/chips/p10/procedures/hwp/perv/p10_extract_sbe_rc.H:44:10: fatal error: p10_sbe_ext_defs.H: No such file or directory
|    44 | #include <p10_sbe_ext_defs.H>

Signed-off-by: Marri Devender Rao <devenrao@in.ibm.com>
Change-Id: Ic2557c441e49e937e5dd4e185c02df7ee46db37d