### PR TITLE
libipl: p10: ipl: Create PEL for empty guard file

### DIFF
--- a/libipl/libipl.H
+++ b/libipl/libipl.H
@@ -40,6 +40,7 @@ enum ipl_error_type {
 	IPL_ERR_SPARE_CLK,
 	IPL_ERR_INVALID_NUM_CLOCK,
 	IPL_ERR_ATTR_WRITE,
+	IPL_ERR_GUARD_PARTITION_ACCESS,
 };
 
 typedef std::map<ipl_error_type, const char *> err_msg_map_type;
@@ -59,7 +60,7 @@ const err_msg_map_type err_msg_map = {
     {IPL_ERR_SPARE_CLK, "Spare Clock initialization is failed"},
     {IPL_ERR_INVALID_NUM_CLOCK, "Invalid number of clock targets found"},
     {IPL_ERR_ATTR_WRITE, "Device tree attribute write failed"},
-};
+    {IPL_ERR_GUARD_PARTITION_ACCESS, "Guard partition access failure"}};
 
 // Error info structure.
 struct ipl_error_info {


### PR DESCRIPTION
libipl: p10: Create PEL for guard file exception
Currently whenever the guard file is empty or does not exist, IPLing is
terminated with an exception.

Fix : During ipl0, while trying to initialize the libguard if any
guard file related exception is triggered, call the registered callback with
IPL_ERR_GUARD_PARTITION_ACCESS to create the according PEL.

Adding the IPL_ERR_GUARD_PARTITION_ACCESS enables us to generate the PEL and "User
Data 1" provides more information regarding the PEL

Tested:
Point to dummy file instead of actual guard file
Using the above error in the ipl callback, able to generate the below PEL
{
    "0x50000E0C": {
        "SRC":                  "BD8D300B",
        "Message":              "Guard partition access failure",
        "PLID":                 "0x50000E0C",
        "CreatorID":            "BMC",
        "Subsystem":            "BMC Firmware",
        "Commit Time":          "10/06/2022 12:33:57",
        "Sev":                  "Predictive Error",
        "CompID":               "0x3000"
    }
}
...
...
    "Error Details": {
        "Message":              "Guard partition access failure"
    },
    "Callout Section": {
        "Callout Count":        "1",
        "Callouts": [{
            "FRU Type":         "Maintenance Procedure Required",
            "Priority":         "Mandatory, replace all with this type as a
unit",
            "Procedure":        "BMC0001"
        }]
    }
},

...
    "LOG011 2022-10-06 13:03:07": "Istep: updatehwmodel: started\n",
    "LOG012 2022-10-06 13:03:07": "updatehwmodel: Genesis mode boot\n",
    "LOG013 2022-10-06 13:03:07": "Guard file
/var/lib/phosphor-software-manager/hostfw/running/NOFILE is empty",

Signed-off-by: deepakala <deepakala.karthikeyan@ibm.com>
Change-Id: I8b9121a76d4dc3b8bc600f0f34ece271c481377b