### PR TITLE
libipl: Add support to log message into journal

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -25,10 +25,21 @@ AC_ARG_ENABLE([libphal],
 		[build phal util library]))
 AM_CONDITIONAL([BUILD_PHAL_API], [test "x$enable_libphal" = "xyes"])
 
+AC_ARG_ENABLE([journal],
+	AS_HELP_STRING([--enable-journal]
+		[enable systemd journal]))
+AM_CONDITIONAL([BUILD_JOURNAL], [test "x$enable_journal" = "xyes"])
+
 if test "x$enable_libphal" = "xyes"; then
 	PKG_CHECK_MODULES([LIBDT_API], [libdt-api])
 	LIBS="$LIBS $LIBDT_API_LIBS"
 	CFLAGS="$CFLAGS $LIBDT_API_CFLAGS"
+fi
+
+if test "x$enable_journal" = "xyes"; then
+	PKG_CHECK_MODULES([LIB_SYSTEMD], [libsystemd])
+	LIBS="$LIBS -lsystemd"
+	CXXFLAGS="$CXXFLAGS -DENABLE_JOURNAL"
 fi
 
 AC_LANG([C++])

--- a/libipl/ipl_settings.C
+++ b/libipl/ipl_settings.C
@@ -3,6 +3,9 @@
 
 #include "libipl.H"
 
+#ifdef ENABLE_JOURNAL
+#include <systemd/sd-journal.h>
+#endif
 struct ipl_settings {
 	enum ipl_mode mode;
 	enum ipl_type type;
@@ -18,7 +21,11 @@ struct ipl_settings {
 
 static void ipl_log_default(void *priv, const char *fmt, va_list ap)
 {
+#ifdef ENABLE_JOURNAL
+	sd_journal_printv(LOG_INFO, fmt, ap);
+#else
 	vfprintf(stdout, fmt, ap);
+#endif
 }
 
 static ipl_settings g_ipl_settings = {


### PR DESCRIPTION
If there is no external log callback setup, the logs were printed on the terminal. But there was no way to look at them later to debug

Now with the compile time flag --enable-journal the logs will be added to journal with the LOG_INFO priority. If the compile time flag is NOT provided, then the logs are printed onto the terminal.

Signed-off-by: Deepa Karthikeyan <deepakala.karthikeyan@ibm.com>