### PR TITLE
Temporary implementation of Extract SBE RC via switching backend

### DIFF
--- a/libphal/libphal.H
+++ b/libphal/libphal.H
@@ -89,7 +89,7 @@ bool isDumpAllowed(struct pdbg_target *proc);
  * Exceptions: SbeError for pdbg lib function failure
  *             std::runtime_error - for file operation failure.
  */
-sbeError_t captureFFDC(struct pdbg_target *proc);
+sbeError_t captureFFDC(struct pdbg_target *&proc);
 
 /**
  * @brief Execute continue mpipl on the pib


### PR DESCRIPTION
It is a temporary implementation of Extract SBE RC procedure via switching backend to KERNEL from SBEFIFO. For test purposes only to review the code flow

Signed-off-by: swarnendu.roy.chowdhury@ibm.com