### PR TITLE
Check for the SBE state before collecting dump

### DIFF
--- a/libphal/phal_exception.H
+++ b/libphal/phal_exception.H
@@ -31,6 +31,7 @@ enum ERR_TYPE {
 	DEVTREE_PRI_PROC_NOT_FOUND,
 	PDBG_FSI_READ_FAIL,
 	PDBG_FSI_WRITE_FAIL,
+	SBE_DUMP_IS_ALREADY_COLLECTED,
 };
 
 // Error type to message map.
@@ -55,8 +56,9 @@ const errMsgMapType errMsgMap = {
     {DEVTREE_ATTR_WRITE_FAIL, "Device Tree attribute write fail"},
     {DEVTREE_PRI_PROC_NOT_FOUND, "Device Tree primary processor not found"},
     {PDBG_FSI_READ_FAIL, "FSI read failed"},
-    {PDBG_FSI_WRITE_FAIL, "FSI write failed"}};
-
+    {PDBG_FSI_WRITE_FAIL, "FSI write failed"},
+    {SBE_DUMP_IS_ALREADY_COLLECTED, "Dump from this SBE is already collected"},
+};
 // phal specific errors base exception class
 struct phalError : public std::exception {
 	virtual ERR_TYPE errType() const noexcept = 0;


### PR DESCRIPTION
This commit adds a check for the SBE state before collecting the SBE dump to prevent multiple collections of the dump.

Test:

Request dump multiple times on same SBE and second time the call should return error.

root@rain104bmc:~# busctl --verbose call xyz.openbmc_project.Dump.Manager /xyz/openbmc_project/dump/sbe xyz.openbmc_project.Dump.Create CreateDump a{sv} 2 "com.ibm.Dump.Create.CreateParameters.ErrorLogId" t 0xDEADBEEF "com.ibm.Dump.Create.CreateParameters.FailingUnitId" t 0
MESSAGE "o" {
        OBJECT_PATH "/xyz/openbmc_project/dump/sbe/entry/30000002";
};

root@rain104bmc:~# busctl --verbose call xyz.openbmc_project.Dump.Manager /xyz/openbmc_project/dump/sbe xyz.openbmc_project.Dump.Create CreateDump a{sv} 2 "com.ibm.Dump.Create.CreateParameters.ErrorLogId" t 0xDEADBEEF "com.ibm.Dump.Create.CreateParameters.FailingUnitId" t 0
MESSAGE "o" {
        OBJECT_PATH "/xyz/openbmc_project/dump/sbe/entry/30000003";
};


Sep 04 20:48:50 rain104bmc phosphor-dump-manager[2882]: Dump is already collected from the SBE on (/proc0)
Sep 04 20:48:50 rain104bmc phosphor-dump-manager[2882]: Dump from this SBE is already collected
Sep 04 20:48:50 rain104bmc phosphor-dump-manager[2870]: Mon Sep  4 20:48:50 UTC 2023 Error: Failed to collect dump, Exiting