### PR TITLE
Added logic for collecting Odyssey SBE dump

### DIFF
--- a/libphal/libphal.H
+++ b/libphal/libphal.H
@@ -280,10 +280,11 @@ namespace dump
  * @param[in] id Id of the dump
  * @param[in] failingUnit Id of proc containing failing SBE
  * @param[in] dumpPath Path to stored the dump files
- *
+ * @param[in] sbeTypeId ID for SBE type i.e.; Odyssey or normal memory chip
+ * 						0xA-->Normal SBE type, 0xB-->Odyssey SBE type
  * Exceptions: PDBG_INIT_FAIL for any pdbg init related failure.
  */
 void collectSBEDump(uint32_t id, uint32_t failingUnit,
-		    const std::filesystem::path &dumpPath);
+		    const std::filesystem::path &dumpPath, const int sbeTypeId);
 } // namespace dump
 } // namespace openpower::phal

--- a/libphal/phal_dump.C
+++ b/libphal/phal_dump.C
@@ -285,11 +285,14 @@ void writeDumpFile(char* data, size_t len, std::filesystem::path& dumpPath)
 }
 
 void collectSBEDump(uint32_t id, uint32_t failingUnit,
-		    const std::filesystem::path& dumpPath)
+		    const std::filesystem::path& dumpPath, const int sbeTypeId)
 {
+	if (sbeTypeId != static_cast<uint16_t>(10))
+		throw dumpError_t(exception::HWP_EXECUTION_FAILED);
+
 	log(level::INFO,
-	    "Collecting SBE dump: path=%s, id=%d, chip position=%d",
-	    dumpPath.string().c_str(), id, failingUnit);
+		"Collecting SBE dump: path=%s, id=%d, chip position=%d",
+		dumpPath.string().c_str(), id, failingUnit);
 
 	std::stringstream ss;
 	ss << std::setw(8) << std::setfill('0') << id;


### PR DESCRIPTION
Changes are been made to handle the SBE dump collection scenarios for Odyssey memory chip.

The changes are been tested on local machine with full OpenBMC build and looks good. PFA the build compeltion screenshot.
![Xnip2023-11-20_16-02-31](https://github.com/open-power/ipl/assets/112170550/65b9d3cd-8e86-4e66-b4de-78384d83124d)
