### PR TITLE
Merging missing commits in open-power/ipl

### DIFF
--- a/libphal/libphal.H
+++ b/libphal/libphal.H
@@ -271,6 +271,15 @@ void putCFAM(struct pdbg_target *proc, const uint32_t addr, const uint32_t val);
  */
 bool isSbeVitalAttnActive(struct pdbg_target *proc);
 
+/**
+ * @brief Check if Hostboot has completed and the control transistioned to Host/PHYP
+ *
+ * @return true when we have moved to PHYP
+ * @return false if there is any error in reading the scom address, 
+ * consider control still in hostboot
+ */
+bool hasControlTransitionedToHost();
+
 } // namespace pdbg
 
 namespace dump

--- a/libphal/phal_pdbg.C
+++ b/libphal/phal_pdbg.C
@@ -280,4 +280,26 @@ bool isSbeVitalAttnActive(struct pdbg_target *proc)
 	return validAttn;
 }
 
+bool hasControlTransitionedToHost()
+{
+  //Read the scratch register to find if the control has moved to phyp (Host)
+  auto pibTarget = pdbg_target_from_path(nullptr, "/proc0/pib");
+
+  uint64_t l_coreScratchRegData = 0xFFFFFFFFFFFFFFFFull;
+  // HB changes the below core scratch reg as one of the last instructions that is run,
+  // so if that is zero then we're in phyp
+  uint64_t l_coreScratchRegAddr = 0x4602F489;
+
+  // Is there any error in reading the scom address, consider control is in hostboot
+  if (pib_read(pibTarget, l_coreScratchRegAddr, &l_coreScratchRegData))
+  {
+    // If unable to read the register, by default consider the control is in hostboot
+    log(level::ERROR, "scom read error: 0x%X", l_coreScratchRegAddr );
+    return false;
+  }
+
+  // If the register reads zero, return control moved to host.
+  return (l_coreScratchRegData == 0);
+}
+
 } // namespace openpower::phal::pdbg


### PR DESCRIPTION
In OpenBMC 1050 branch for some unavoidable reasons we have to create a mirror of open-power/ipl repo under ibm-openbmc. But that was a temporary solution and ultimately we need to move back to open-power/ipl in 1060 branch. This commit merges the missing/exclusive commits from ibm-openbmc/ipl repo into the open-power/ipl repo so that we can move back to original open-power/ipl repo in OpenBMC 1060 branch.

Missign commits which are merged are:
8c2272cc5a9030acc459e0ccb3f5e561511d344b from ibm-openbmc/ipl-1050 033bf30ce7a906e08d96790434174f706f607fb4 from ibm-openbmc/ipl-1050 (This one was ported to 1020 and 1030 as well)

The commits which were already availbale in open-power/ipl-main are: ec7d067c7dec06f61d92d186a23e9e8fe1ee4c99 from ibm-openbmc/ipl-1020 6a4a7696a94c06e34fece077236861d291df8508 from ibm-openbmc/ipl-1020 9e84ef27c631457f829166b383c64c9d90c792d4 from ibm-openbmc/ipl-1020 (Actually it combines the above two)

4882ca795c0e69b606860b79cc91d03f834ec92e from ibm-openbmc/ipl-1020