### PR TITLE
Odyssey SBE dump collection support code added

### DIFF
--- a/libphal/phal_dump.C
+++ b/libphal/phal_dump.C
@@ -109,17 +109,18 @@ static constexpr int ODYSSEY_SBE_DUMP = 0xB;
 
 /**
  * @brief Get the Fapi Unit Pos object for OCMB
- * 
+ *
  * @param target The target
  * @return uint8_t The position
  */
-uint32_t getFapiUnitPos(pdbg_target *target)
+uint32_t getFapiUnitPos(pdbg_target* target)
 {
-  uint32_t fapiUnitPos = 0; // chip unit position
-  if (!pdbg_target_get_attribute(target, "ATTR_FAPI_POS", 4, 1, &fapiUnitPos))
-    log(level::ERROR, "ATTR_FAPI_POS Attribute get failed");
-  
-  return fapiUnitPos;
+	uint32_t fapiUnitPos = 0; // chip unit position
+	if (!pdbg_target_get_attribute(target, "ATTR_FAPI_POS", 4, 1,
+				       &fapiUnitPos))
+		log(level::ERROR, "ATTR_FAPI_POS Attribute get failed");
+
+	return fapiUnitPos;
 }
 
 /**
@@ -131,7 +132,8 @@ uint32_t getFapiUnitPos(pdbg_target *target)
  *
  * Exceptions: PDBG_TARGET_NOT_OPERATIONAL if target is not available
  */
-struct pdbg_target* getTargetFromFailingId(const uint32_t failingUnit, const int sbeTypeId)
+struct pdbg_target* getTargetFromFailingId(const uint32_t failingUnit,
+					   const int sbeTypeId)
 {
 	struct pdbg_target* chip = nullptr;
 	struct pdbg_target* target = nullptr;
@@ -149,16 +151,18 @@ struct pdbg_target* getTargetFromFailingId(const uint32_t failingUnit, const int
 			targetIdx = getFapiUnitPos(target);
 		else if (sbeTypeId == PROC_SBE_DUMP)
 			targetIdx = pdbg_target_index(target);
-		
+
 		if (targetIdx != failingUnit) {
 			continue;
 		}
-		if (sbeTypeId == ODYSSEY_SBE_DUMP)
-		{
-			if (!openpower::phal::sbe::is_ody_ocmb_chip(target))
-			{
-				log(level::ERROR, "No ocmb target found to execute the dump for failing unit=%d", failingUnit);
-				throw sbeError_t(exception::PDBG_TARGET_NOT_OPERATIONAL);
+		if (sbeTypeId == ODYSSEY_SBE_DUMP) {
+			if (!openpower::phal::sbe::is_ody_ocmb_chip(target)) {
+				log(level::ERROR,
+				    "No ocmb target found to execute the dump "
+				    "for failing unit=%d",
+				    failingUnit);
+				throw sbeError_t(
+				    exception::PDBG_TARGET_NOT_OPERATIONAL);
 			}
 		}
 		if (pdbg_target_probe(target) != PDBG_TARGET_ENABLED) {
@@ -230,7 +234,7 @@ void initializePdbgLibEkb()
 
 /**
  * @brief Checks the SBE state
- * 
+ *
  * @param pib The pib target
  * @param target The target (OCMB or proc)
  */
@@ -241,47 +245,46 @@ void checkSbeState(struct pdbg_target* pib, struct pdbg_target* target)
 	// If the SBE dump is already collected return error
 	if (sbe_get_state(pib, &state)) {
 		log(level::ERROR, "Failed to read SBE state information (%s)",
-				pdbg_target_path(target));
+		    pdbg_target_path(target));
 		throw sbeError_t(exception::SBE_STATE_READ_FAIL);
-	
 	}
 
 	if (state == SBE_STATE_FAILED) {
-		log(level::ERROR, "Dump is already collected from the "
-				"SBE on (%s)", pdbg_target_path(target));
+		log(level::ERROR,
+		    "Dump is already collected from the "
+		    "SBE on (%s)",
+		    pdbg_target_path(target));
 		throw sbeError_t(exception::SBE_DUMP_IS_ALREADY_COLLECTED);
 	}
 }
 
 /**
- * @brief Extracts SBE RC from the corrupted chip and writes the info into a dump file
- * 
+ * @brief Extracts SBE RC from the corrupted chip and writes the info into a
+ * dump file
+ *
  * @param target The chip target
  * @param dumpPath The path of the dump file
  * @param sbeTypeId The chip type, i.e.; proc or OCMB
  */
-void extractSbeRc(struct pdbg_target* target, const std::filesystem::path& dumpPath, const int sbeTypeId)
+void extractSbeRc(struct pdbg_target* target,
+		  const std::filesystem::path& dumpPath, const int sbeTypeId)
 {
 	// Execute SBE extract rc to set up sdb bit for pibmem dump to work
 	fapi2::ReturnCode fapiRc;
 	P10_EXTRACT_SBE_RC::RETURN_ACTION recovAction = {};
 	std::string targetTypeString;
 
-	if (ODYSSEY_SBE_DUMP == sbeTypeId)
-	{
+	if (ODYSSEY_SBE_DUMP == sbeTypeId) {
 		// ody_extract_sbe_rc is returning the error.
 		fapiRc = ody_extract_sbe_rc(target);
 		targetTypeString = "ocmb";
-	}
-	else if (PROC_SBE_DUMP == sbeTypeId)
-	{
+	} else if (PROC_SBE_DUMP == sbeTypeId) {
 		// p10_extract_sbe_rc is returning the error along with
 		// recovery action, so not checking the fapirc.
 		fapiRc = p10_extract_sbe_rc(target, recovAction, true);
 		targetTypeString = "proc";
 	}
-	log(level::INFO,
-	    "extract_sbe_rc for %s=%s returned rc=0x%08X ",
+	log(level::INFO, "extract_sbe_rc for %s=%s returned rc=0x%08X ",
 	    targetTypeString, pdbg_target_path(target), fapiRc);
 
 	writeSbeData(dumpPath, fapiRc, recovAction);
@@ -289,29 +292,26 @@ void extractSbeRc(struct pdbg_target* target, const std::filesystem::path& dumpP
 
 /**
  * @brief Probes and returns the corresponding PIB target of the chip
- * 
+ *
  * @param target The target chip
  * @param sbeTypeId The chip type number
  * @return struct pdbg_target* The pib target obtained
  */
-struct pdbg_target* probePibTarget(struct pdbg_target* target, const int sbeTypeId)
+struct pdbg_target* probePibTarget(struct pdbg_target* target,
+				   const int sbeTypeId)
 {
 	// PIB target for executing HWP
-	struct pdbg_target *pib = nullptr;
-	if (sbeTypeId == PROC_SBE_DUMP)
-	{
+	struct pdbg_target* pib = nullptr;
+	if (sbeTypeId == PROC_SBE_DUMP) {
 		char path[16];
 		sprintf(path, "/proc%d/pib", pdbg_target_index(target));
 		pib = pdbg_target_from_path(nullptr, path);
-	}
-	else if (sbeTypeId == ODYSSEY_SBE_DUMP)
-	{
+	} else if (sbeTypeId == ODYSSEY_SBE_DUMP) {
 		pib = get_ody_pib_target(target);
 	}
-	if (!pib) 
-	{
+	if (!pib) {
 		log(level::ERROR, "Failed to get PIB target for(%s)",
-			pdbg_target_path(target));
+		    pdbg_target_path(target));
 		throw dumpError_t(exception::PDBG_TARGET_NOT_OPERATIONAL);
 	}
 	// Probe PIB for HWP execution
@@ -332,7 +332,8 @@ struct pdbg_target* probePibTarget(struct pdbg_target* target, const int sbeType
  *             HWP_EXECUTION_FAILED if the extract rc procedure is failing
  */
 struct pdbg_target* preCollection(const uint32_t failingUnit,
-				  const std::filesystem::path& dumpPath, const int sbeTypeId)
+				  const std::filesystem::path& dumpPath,
+				  const int sbeTypeId)
 {
 	initializePdbgLibEkb();
 	// Find the proc target from the failing unit id
@@ -377,51 +378,53 @@ void writeDumpFile(char* data, size_t len, std::filesystem::path& dumpPath)
 
 /**
  * @brief Writes the dump data contents in the register into the dump file
- * 
+ *
  * @tparam DumpRegVal A templated vector of various possible dump type registers
  * @param dumpRegs Dump register
  * @param basePath File base path
  * @param dumpType Type of dump, e.g; pibms/pibmem/sbe local reg etc
  */
-template<typename DumpRegVal>
-void writeDumpFileForDumpContents(std::vector<DumpRegVal>& dumpRegs, std::filesystem::path& basePath, const std::string_view dumpType)
+template <typename DumpRegVal>
+void writeDumpFileForDumpContents(std::vector<DumpRegVal>& dumpRegs,
+				  std::filesystem::path& basePath,
+				  const std::string_view dumpType)
 {
 	try {
-		writeDumpFile(
-			reinterpret_cast<char*>(&dumpRegs[0]),
-			sizeof(DumpRegVal) * dumpRegs.size(),
-			basePath);
+		writeDumpFile(reinterpret_cast<char*>(&dumpRegs[0]),
+			      sizeof(DumpRegVal) * dumpRegs.size(), basePath);
 	} catch (const dumpError_t& e) {
 		log(level::ERROR,
-			"Error in writing %s "
-			"file "
-			"errorMsg=%s",
-			dumpType.data(), e.what());
+		    "Error in writing %s "
+		    "file "
+		    "errorMsg=%s",
+		    dumpType.data(), e.what());
 		throw;
 	}
 }
 
 /**
  * @brief Collects the PPE state data for both p10 and Odyssey
- * 
+ *
  * @param failingUnit Position of the proc containing the failed SBE
  * @param baseFilename Base file name of the dump
  * @param dumpPath The dump path
  * @param sbeTypeId The type of failed SBE chip, i.e.; p10 or Odyssey
  */
-void collectPPEStateData(struct pdbg_target* target, const std::string& baseFilename, const std::filesystem::path& dumpPath, const int sbeTypeId)
+void collectPPEStateData(struct pdbg_target* target,
+			 const std::string& baseFilename,
+			 const std::filesystem::path& dumpPath,
+			 const int sbeTypeId)
 {
 	// Dump the PPE state based on the based base address
 	PPE_DUMP_MODE mode = SNAPSHOT;
 	std::vector<Reg32Value_t> ppeGprsValue;
 	std::vector<Reg32Value_t> ppeSprsValue;
 	std::vector<Reg32Value_t> ppeXirsValue;
-	PPE_TYPES type = PPE_TYPE_SBE;	//By default it is for p10 chip type
-	uint32_t instanceNum = 0;	//By default it is for p10 chip type
-	auto chip = target;	//By default it is for p10 chip type
+	PPE_TYPES type = PPE_TYPE_SBE; // By default it is for p10 chip type
+	uint32_t instanceNum = 0;      // By default it is for p10 chip type
+	auto chip = target;	       // By default it is for p10 chip type
 
-	if (sbeTypeId == ODYSSEY_SBE_DUMP)
-	{
+	if (sbeTypeId == ODYSSEY_SBE_DUMP) {
 		type = PPE_TYPE_SPPE;
 		chip = pdbg_target_parent("proc", target);
 		instanceNum = getFapiUnitPos(target);
@@ -429,18 +432,17 @@ void collectPPEStateData(struct pdbg_target* target, const std::string& baseFile
 
 	// The processor chip should be of proc type while collecting
 	// PPE dump data for both p10 and Odyssey as per the HWP team
-	auto fapiRc =
-		p10_ppe_state(chip, type, instanceNum, mode, ppeGprsValue,
-			ppeSprsValue, ppeXirsValue);
+	auto fapiRc = p10_ppe_state(chip, type, instanceNum, mode, ppeGprsValue,
+				    ppeSprsValue, ppeXirsValue);
 	if (fapiRc != fapi2::FAPI2_RC_SUCCESS) {
 		if (sbeTypeId == ODYSSEY_SBE_DUMP)
 			log(level::ERROR,
-				"Failed in ody_ppe_state for proc=%s, rc=0x%08X",
-				pdbg_target_path(chip), fapiRc);
+			    "Failed in ody_ppe_state for proc=%s, rc=0x%08X",
+			    pdbg_target_path(chip), fapiRc);
 		else
 			log(level::ERROR,
-				"Failed in p10_ppe_state for proc=%s, rc=0x%08X",
-				pdbg_target_path(chip), fapiRc);
+			    "Failed in p10_ppe_state for proc=%s, rc=0x%08X",
+			    pdbg_target_path(chip), fapiRc);
 	} else {
 		std::vector<DumpPPERegValue> ppeState;
 		for (auto& spr : ppeSprsValue) {
@@ -454,15 +456,20 @@ void collectPPEStateData(struct pdbg_target* target, const std::string& baseFile
 		}
 
 		std::string dumpFilename =
-			baseFilename + ((sbeTypeId == ODYSSEY_SBE_DUMP) ? "ody_ppe_state" : "p10_ppe_state");
-		std::filesystem::path basePath =
-			dumpPath / dumpFilename;
-		auto dumpTypeName = (sbeTypeId == ODYSSEY_SBE_DUMP) ? "ody_ppe_state" : "p10_ppe_state";
+		    baseFilename + ((sbeTypeId == ODYSSEY_SBE_DUMP)
+					? "ody_ppe_state"
+					: "p10_ppe_state");
+		std::filesystem::path basePath = dumpPath / dumpFilename;
+		auto dumpTypeName = (sbeTypeId == ODYSSEY_SBE_DUMP)
+					? "ody_ppe_state"
+					: "p10_ppe_state";
 		writeDumpFileForDumpContents(ppeState, basePath, dumpTypeName);
 	}
 }
 
-void collectSBEDumpForOdy(struct pdbg_target* ocmb, uint32_t id, uint32_t failingUnit, const std::filesystem::path& dumpPath)
+void collectSBEDumpForOdy(struct pdbg_target* ocmb, uint32_t id,
+			  uint32_t failingUnit,
+			  const std::filesystem::path& dumpPath)
 {
 	std::stringstream ss;
 	ss << std::setw(8) << std::setfill('0') << id;
@@ -471,27 +478,27 @@ void collectSBEDumpForOdy(struct pdbg_target* ocmb, uint32_t id, uint32_t failin
 	// <dumpID>.<nodeNUM>_<ocmbNum>.Sbedata_p10_<HWP name>
 	std::string baseFilename =
 	    ss.str() + ".0_" + std::to_string(failingUnit) + "_SbeData_ody_";
-		
+
 	// Collect SBE local register dump
 	std::vector<SBE_SCOMReg_Value_t> sbeScomRegValue;
 	auto fapiRc = ody_sbe_localreg_dump(ocmb, true, sbeScomRegValue);
 	if (fapiRc != fapi2::FAPI2_RC_SUCCESS) {
 		log(level::ERROR,
-			"Failed in ody_sbe_localreg_dump for ocmb=%s, "
-			"rc=0x%08X",
-			pdbg_target_path(ocmb), fapiRc);
+		    "Failed in ody_sbe_localreg_dump for ocmb=%s, "
+		    "rc=0x%08X",
+		    pdbg_target_path(ocmb), fapiRc);
 	} else {
 		std::vector<DumpSBERegVal> dumpRegs;
 		for (auto& reg : sbeScomRegValue) {
-			dumpRegs.emplace_back(reg.reg.number,
-							reg.reg.name, reg.value);
+			dumpRegs.emplace_back(reg.reg.number, reg.reg.name,
+					      reg.value);
 		}
 		std::string dumpFilename =
-			baseFilename + "ody_sbe_localreg_dump";
-		std::filesystem::path basePath =
-			dumpPath / dumpFilename;
+		    baseFilename + "ody_sbe_localreg_dump";
+		std::filesystem::path basePath = dumpPath / dumpFilename;
 
-		writeDumpFileForDumpContents(dumpRegs, basePath, "ody_sbe_localreg_dump");
+		writeDumpFileForDumpContents(dumpRegs, basePath,
+					     "ody_sbe_localreg_dump");
 	}
 
 	// Dump contents of various PIB Masters and Slaves internal
@@ -506,21 +513,19 @@ void collectSBEDumpForOdy(struct pdbg_target* ocmb, uint32_t id, uint32_t failin
 	fapiRc = ody_pibms_reg_dump(ocmb, pibmsRegSet);
 	if (fapiRc != fapi2::FAPI2_RC_SUCCESS) {
 		log(level::ERROR,
-			"Failed in ody_pibms_reg_dump for ocmb=%s, "
-			"rc=0x%08X",
-			pdbg_target_path(ocmb), fapiRc);
+		    "Failed in ody_pibms_reg_dump for ocmb=%s, "
+		    "rc=0x%08X",
+		    pdbg_target_path(ocmb), fapiRc);
 	} else {
 		std::vector<DumpPIBMSRegVal> dumpRegs;
 		for (auto& regs : pibmsRegSet) {
-			dumpRegs.emplace_back(
-				regs.reg.addr, regs.reg.name, regs.reg.attr,
-				regs.value);
+			dumpRegs.emplace_back(regs.reg.addr, regs.reg.name,
+					      regs.reg.attr, regs.value);
 		}
-		std::string dumpFilename =
-			baseFilename + "ody_pibms_reg_dump";
-		std::filesystem::path basePath =
-			dumpPath / dumpFilename;
-		writeDumpFileForDumpContents(dumpRegs, basePath, "ody_pibms_reg_dump");
+		std::string dumpFilename = baseFilename + "ody_pibms_reg_dump";
+		std::filesystem::path basePath = dumpPath / dumpFilename;
+		writeDumpFileForDumpContents(dumpRegs, basePath,
+					     "ody_pibms_reg_dump");
 	}
 
 	// Dump the PIBMEM Array based on starting and number of address
@@ -531,23 +536,21 @@ void collectSBEDumpForOdy(struct pdbg_target* ocmb, uint32_t id, uint32_t failin
 	static constexpr uint32_t pibmemDumpNumOfByte = 0x7D400;
 	usr_options userOptions = INTERMEDIATE_TO_INTERMEDIATE;
 
-	fapiRc = ody_pibmem_dump(ocmb, pibmemDumpStartByte,
-					pibmemDumpNumOfByte, userOptions,
-					eccEnable, pibmemContents);
+	fapiRc = ody_pibmem_dump(ocmb, pibmemDumpStartByte, pibmemDumpNumOfByte,
+				 userOptions, eccEnable, pibmemContents);
 	if (fapiRc != fapi2::FAPI2_RC_SUCCESS) {
 		log(level::ERROR,
-			"Failed in ody_pibmem_dump for ocmb=%s, rc=0x%08X",
-			pdbg_target_path(ocmb), fapiRc);
+		    "Failed in ody_pibmem_dump for ocmb=%s, rc=0x%08X",
+		    pdbg_target_path(ocmb), fapiRc);
 	} else {
 		std::vector<uint64_t> dumpData;
 		for (auto& data : pibmemContents) {
 			dumpData.push_back(data.rd_data);
 		}
-		std::string dumpFilename =
-			baseFilename + "ody_pibmem_dump";
-		std::filesystem::path basePath =
-			dumpPath / dumpFilename;
-		writeDumpFileForDumpContents(dumpData, basePath, "ody_pibmem_dump");
+		std::string dumpFilename = baseFilename + "ody_pibmem_dump";
+		std::filesystem::path basePath = dumpPath / dumpFilename;
+		writeDumpFileForDumpContents(dumpData, basePath,
+					     "ody_pibmem_dump");
 	}
 	// Dump the PPE state based on the based base address
 	collectPPEStateData(ocmb, baseFilename, dumpPath, ODYSSEY_SBE_DUMP);
@@ -557,8 +560,8 @@ void collectSBEDump(uint32_t id, uint32_t failingUnit,
 		    const std::filesystem::path& dumpPath, const int sbeTypeId)
 {
 	log(level::INFO,
-		"Collecting SBE dump: path=%s, id=%d, chip position=%d",
-		dumpPath.string().c_str(), id, failingUnit);
+	    "Collecting SBE dump: path=%s, id=%d, chip position=%d",
+	    dumpPath.string().c_str(), id, failingUnit);
 
 	std::stringstream ss;
 	ss << std::setw(8) << std::setfill('0') << id;
@@ -566,7 +569,7 @@ void collectSBEDump(uint32_t id, uint32_t failingUnit,
 	// Filename format
 	// <dumpID>.<nodeNUM>_<procNum>.Sbedata_p10_<HWP name>
 	std::string baseFilename =
-		ss.str() + ".0_" + std::to_string(failingUnit) + "_SbeData_p10_";
+	    ss.str() + ".0_" + std::to_string(failingUnit) + "_SbeData_p10_";
 
 	// Execute pre-collection and get chip corresponding to failing unit
 	auto chip = preCollection(failingUnit, dumpPath, sbeTypeId);
@@ -578,42 +581,44 @@ void collectSBEDump(uint32_t id, uint32_t failingUnit,
 	if (0 > sbe_set_state(pib, SBE_STATE_DEBUG_MODE)) {
 		log(level::ERROR, "Setting SBE state to debug mode failed");
 		throw std::runtime_error(
-			"Setting SBE state to debug mode failed");
+		    "Setting SBE state to debug mode failed");
 	}
 
 	fapi2::ReturnCode fapiRc;
 
 	try {
-		if (ODYSSEY_SBE_DUMP == sbeTypeId)
-		{
+		if (ODYSSEY_SBE_DUMP == sbeTypeId) {
 			collectSBEDumpForOdy(chip, id, failingUnit, dumpPath);
-		}
-		else
-		{
+		} else {
 			// Collect SBE local register dump
 			std::vector<SBESCOMRegValue_t> sbeScomRegValue;
-			fapiRc = p10_sbe_localreg_dump(chip, true, sbeScomRegValue);
+			fapiRc =
+			    p10_sbe_localreg_dump(chip, true, sbeScomRegValue);
 			if (fapiRc != fapi2::FAPI2_RC_SUCCESS) {
 				log(level::ERROR,
-					"Failed in p10_sbe_localreg_dump for proc=%s, "
-					"rc=0x%08X",
-					pdbg_target_path(chip), fapiRc);
+				    "Failed in p10_sbe_localreg_dump for "
+				    "proc=%s, "
+				    "rc=0x%08X",
+				    pdbg_target_path(chip), fapiRc);
 			} else {
 				std::vector<DumpSBERegVal> dumpRegs;
 				for (auto& reg : sbeScomRegValue) {
 					dumpRegs.emplace_back(reg.reg.number,
-								reg.reg.name, reg.value);
+							      reg.reg.name,
+							      reg.value);
 				}
 				std::string dumpFilename =
-					baseFilename + "p10_sbe_localreg_dump";
+				    baseFilename + "p10_sbe_localreg_dump";
 				std::filesystem::path basePath =
-					dumpPath / dumpFilename;
+				    dumpPath / dumpFilename;
 
-				writeDumpFileForDumpContents(dumpRegs, basePath, "p10_sbe_localreg_dump");
+				writeDumpFileForDumpContents(
+				    dumpRegs, basePath,
+				    "p10_sbe_localreg_dump");
 			}
 
-			// Dump contents of various PIB Masters and Slaves internal
-			// registers
+			// Dump contents of various PIB Masters and Slaves
+			// internal registers
 			std::vector<sRegV> pibmsRegSet;
 			for (auto& reg : pibms_regs_2dump) {
 				sRegV regv;
@@ -624,53 +629,59 @@ void collectSBEDump(uint32_t id, uint32_t failingUnit,
 			fapiRc = p10_pibms_reg_dump(chip, pibmsRegSet);
 			if (fapiRc != fapi2::FAPI2_RC_SUCCESS) {
 				log(level::ERROR,
-					"Failed in p10_pibms_reg_dump for proc=%s, "
-					"rc=0x%08X",
-					pdbg_target_path(chip), fapiRc);
+				    "Failed in p10_pibms_reg_dump for proc=%s, "
+				    "rc=0x%08X",
+				    pdbg_target_path(chip), fapiRc);
 			} else {
 				std::vector<DumpPIBMSRegVal> dumpRegs;
 				for (sRegV& regs : pibmsRegSet) {
 					dumpRegs.emplace_back(
-						regs.reg.addr, regs.reg.name, regs.reg.attr,
-						regs.value);
+					    regs.reg.addr, regs.reg.name,
+					    regs.reg.attr, regs.value);
 				}
 				std::string dumpFilename =
-					baseFilename + "p10_pibms_reg_dump";
+				    baseFilename + "p10_pibms_reg_dump";
 				std::filesystem::path basePath =
-					dumpPath / dumpFilename;
-				
-				writeDumpFileForDumpContents(dumpRegs, basePath, "p10_pibms_reg_dump");
+				    dumpPath / dumpFilename;
+
+				writeDumpFileForDumpContents(
+				    dumpRegs, basePath, "p10_pibms_reg_dump");
 			}
 
-			// Dump the PIBMEM Array based on starting and number of address
+			// Dump the PIBMEM Array based on starting and number of
+			// address
 			std::vector<array_data_t> pibmemContents;
 			bool eccEnable = false;
 			uint32_t pibmemDumpStartByte = 0;
 			// Number of bytes to be read from PIBMEM
 			static constexpr uint32_t pibmemDumpNumOfByte = 0x7D400;
-			user_options userOptions = INTERMEDIATE_TILL_INTERMEDIATE;
+			user_options userOptions =
+			    INTERMEDIATE_TILL_INTERMEDIATE;
 
-			fapiRc = p10_pibmem_dump(chip, pibmemDumpStartByte,
-						pibmemDumpNumOfByte, userOptions,
-						pibmemContents, eccEnable);
+			fapiRc = p10_pibmem_dump(
+			    chip, pibmemDumpStartByte, pibmemDumpNumOfByte,
+			    userOptions, pibmemContents, eccEnable);
 			if (fapiRc != fapi2::FAPI2_RC_SUCCESS) {
 				log(level::ERROR,
-					"Failed in p10_pibmem_dump for proc=%s, rc=0x%08X",
-					pdbg_target_path(chip), fapiRc);
+				    "Failed in p10_pibmem_dump for proc=%s, "
+				    "rc=0x%08X",
+				    pdbg_target_path(chip), fapiRc);
 			} else {
 				std::vector<uint64_t> dumpData;
 				for (auto& data : pibmemContents) {
 					dumpData.push_back(data.read_data);
 				}
 				std::string dumpFilename =
-					baseFilename + "p10_pibmem_dump";
+				    baseFilename + "p10_pibmem_dump";
 				std::filesystem::path basePath =
-					dumpPath / dumpFilename;
+				    dumpPath / dumpFilename;
 
-				writeDumpFileForDumpContents(dumpData, basePath, "p10_pibmem_dump");
+				writeDumpFileForDumpContents(dumpData, basePath,
+							     "p10_pibmem_dump");
 			}
 			// Dump the PPE state based on the based base address
-			collectPPEStateData(chip, baseFilename, dumpPath, PROC_SBE_DUMP);
+			collectPPEStateData(chip, baseFilename, dumpPath,
+					    PROC_SBE_DUMP);
 		}
 	} catch (const std::exception& e) {
 		log(level::ERROR, "Failed to collect the SBE dump");


### PR DESCRIPTION
We have now OdySsey chip along with the existing p10 which supports SBE dump collection. In future we may have more varities of chips. So the new code to support Odyssey operation has been added as separate methods to seggregate the different chip types and avoid confusion.

Test:

busctl --verbose call org.open_power.Dump.Manager /org/openpower/dump xyz.openbmc_project.Dump.Create CreateDump a{sv} 3  "com.ibm.Dump.Create.CreateParameters.DumpType" s "com.ibm.Dump.Create.DumpType.MemoryBufferSBE" "com.ibm.Dump.Create.CreateParameters.ErrorLogId" t 0xDEADBEEF "com.ibm.Dump.Create.CreateParameters.FailingUnitId" t 2

MESSAGE "o" {
        OBJECT_PATH "/xyz/openbmc_project/dump/msbe/entry/40000008";
};

root@ever6bmc:/tmp/src# journalctl -f
Jan 16 06:27:48 ever6bmc phosphor-dump-manager[4834]: Creating dump with dumpPath(/var/lib/phosphor-debug-collector/msbedump/40000008) id(40000008) available space(102400) eid(deadbeef) dump type(11) failing unit(2)
Jan 16 06:27:48 ever6bmc phosphor-dump-manager[4846]: Entering collectSBEDumpForOdy
Jan 16 06:27:48 ever6bmc phosphor-dump-manager[4846]: Collecting SBE dump: path=/tmp/dump_40000008_1705386468/plat_dump, id=40000008, chip position=2
Jan 16 06:27:48 ever6bmc phosphor-dump-manager[4846]: Going to call preCollectionOdy
Jan 16 06:27:48 ever6bmc phosphor-dump-manager[4846]: PDBG Initilization started
Jan 16 06:27:48 ever6bmc phosphor-dump-manager[4846]: OCMB chip type validated
Jan 16 06:27:48 ever6bmc phosphor-dump-manager[4846]: err: ody_extract_sbe_rc:269 The external halt_req input was active.
Jan 16 06:27:48 ever6bmc phosphor-dump-manager[4846]: err: ody_extract_sbe_rc:467 Instruction machine check at Address = FFF80014
Jan 16 06:27:48 ever6bmc phosphor-dump-manager[4846]: ody_extract_sbe_rc for ocmb=/proc0/pib/perv12/mc0/mi0/mcc1/omi0/ocmb0 returned rc=0x7EDA2EF4
Jan 16 06:27:48 ever6bmc phosphor-dump-manager[4846]: Returned from call preCollectionOdy
Jan 16 06:30:33 ever6bmc phosphor-dump-manager[4846]: writng dump data to file
Jan 16 06:30:33 ever6bmc phosphor-dump-manager[4846]: writng dump data to file
Jan 16 06:30:33 ever6bmc phosphor-dump-manager[4846]: writng dump data to file
Jan 16 06:30:33 ever6bmc phosphor-dump-manager[4846]: err: ppe_state_data:142 Error in GETSCOM
Jan 16 06:30:33 ever6bmc phosphor-dump-manager[4846]: Failed in ody_ppe_state for proc=/proc2, rc=0x7EDA2EB8
Jan 16 06:30:33 ever6bmc phosphor-dump-manager[4846]: SBE dump collected
Jan 16 06:30:33 ever6bmc phosphor-dump-manager[4846]: Exiting collectSBEDumpForOdy
Jan 16 06:30:33 ever6bmc phosphor-dump-manager[4892]: plat_dump/40000008.0_2_SbeData_ody_ody_pibmem_dump
Jan 16 06:30:33 ever6bmc phosphor-dump-manager[4892]: plat_dump/40000008.0_2_SbeData_ody_ody_pibms_reg_dump
Jan 16 06:30:33 ever6bmc phosphor-dump-manager[4892]: plat_dump/40000008.0_2_SbeData_ody_ody_sbe_localreg_dump
Jan 16 06:30:33 ever6bmc phosphor-dump-manager[4892]: info.yaml
Jan 16 06:30:33 ever6bmc phosphor-dump-manager[4834]: Adding Dump Header :/usr/share/dreport.d/include.d/gendumpheader
Jan 16 06:30:35 ever6bmc bmcweb[903]: (2024-01-16 06:30:35) [ERROR "event_dbus_monitor.hpp":468] Invalid dump type received when listening for dump created signal
Jan 16 06:30:35 ever6bmc phosphor-dump-manager[4834]: Tue Jan 16 06:30:35 UTC 2024 Successfully completed
Jan 16 06:30:35 ever6bmc phosphor-dump-manager[497]: OriginatorId is not provided
Jan 16 06:30:35 ever6bmc phosphor-dump-manager[497]: OriginatorType is not provided. Replacing the string with the default value
Jan 16 06:30:35 ever6bmc phosphor-dump-manager[4834]: BMC dump initiated o "/xyz/openbmc_project/dump/bmc/entry/1"
Jan 16 06:30:35 ever6bmc pvm_dump_offload[3636]: Watch interfaceAdded path (/xyz/openbmc_project/dump/bmc/entry/1)
Jan 16 06:30:35 ever6bmc phosphor-dump-manager[497]: Dump packaging completed
