### PR TITLE
Restructure SBE dump collection for improved maintainability

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-    "files.associations": {
-        "phal_sbe.C": "cpp",
-        "phal_pdbg.C": "cpp"
-    }
-}

--- a/libphal/phal_dump.C
+++ b/libphal/phal_dump.C
@@ -32,6 +32,7 @@ namespace dump
 
 using namespace openpower::phal::logging;
 using namespace openpower::phal::utils::pdbg;
+using namespace fapi2;
 
 /* SBE register number and name for writing
  * to the file */
@@ -168,329 +169,473 @@ void writeSbeData(const std::filesystem::path& dumpPath, uint32_t reasonCode,
 }
 
 /**
- * @brief Initialize the PDBG and SBE to start collection
- * @param[in] failingUnit Position of the proc containing the failed SBE
+ * @brief Initializes the PDBG and LIBEKB environments.
  *
- * Exceptions: PDBG_INIT_FAIL for any pdbg init related failure.
- *             PDBG_TARGET_NOT_OPERATIONAL for invalid failing unit
- *             HWP_EXECUTION_FAILED if the extract rc procedure is failing
+ * @throw std::runtime_error Throws if either PDBG or LIBEKB initialization
+ * fails.
  */
-struct pdbg_target* preCollection(const uint32_t failingUnit,
-				  const std::filesystem::path& dumpPath)
+void initializePdbgLibEkb()
 {
-	// Initialize PDBG with KERNEL backend
 	pdbg::init(PDBG_BACKEND_KERNEL);
-
 	if (libekb_init()) {
 		log(level::ERROR, "libekb_init failed");
 		throw std::runtime_error("libekb initialization failed");
 	}
+}
 
-	// FSI and PIB targets for executing HWP
-	struct pdbg_target *fsi, *pib;
+/**
+ * @brief Probes a target (FSI or PIB) for the given processor target.
+ * @param[in] proc The processor target to probe the FSI/PIB target for.
+ * @param[in] targetType The type of target to probe ("fsi" or "pib").
+ * @return Pointer to the probed pdbg target. If the target is not operational,
+ *         the function throws an exception.
+ *
+ * @throw dumpError_t Throws if the target is not found or not operational.
+ */
+struct pdbg_target* probeTarget(struct pdbg_target* proc,
+				const char* targetType)
+{
 	char path[16];
-
-	// Find the proc target from the failing unit id
-	struct pdbg_target* proc = getProcFromFailingId(failingUnit);
-
-
-	// Probe FSI for HWP execution
-	sprintf(path, "/proc%d/fsi", pdbg_target_index(proc));
-	fsi = pdbg_target_from_path(NULL, path);
-	if (fsi == nullptr) {
-		log(level::ERROR, "Failed to get FSI target for(%s)",
-		    pdbg_target_path(proc));
+	sprintf(path, "/proc%d/%s", pdbg_target_index(proc), targetType);
+	struct pdbg_target* target = pdbg_target_from_path(NULL, path);
+	if (!target || pdbg_target_probe(target) != PDBG_TARGET_ENABLED) {
+		log(level::ERROR, "Failed to get or probe %s target for (%s)",
+		    targetType, pdbg_target_path(proc));
 		throw dumpError_t(exception::PDBG_TARGET_NOT_OPERATIONAL);
 	}
+	return target;
+}
 
-	// Probe PIB for HWP execution
-	sprintf(path, "/proc%d/pib", pdbg_target_index(proc));
-	pib = pdbg_target_from_path(NULL, path);
-	if (pib == nullptr) {
-		log(level::ERROR, "Failed to get PIB target for(%s)",
-		    pdbg_target_path(proc));
-		throw dumpError_t(exception::PDBG_TARGET_NOT_OPERATIONAL);
-	}
-
-	if ((pdbg_target_probe(fsi) != PDBG_TARGET_ENABLED ||
-	     pdbg_target_probe(pib) != PDBG_TARGET_ENABLED)) {
-		log(level::ERROR, "Failed to prob PIB or FSI");
-		throw dumpError_t(exception::PDBG_TARGET_NOT_OPERATIONAL);
-	}
-
+/**
+ * @brief Checks the state of the SBE on the given PIB target.
+ * @param[in] pib The PIB target to check the SBE state of.
+ *
+ * @throw sbeError_t Throws if the SBE state is 'FAILED' (indicating a dump
+ *        has already been collected) or if there is a failure in reading the
+ * SBE state.
+ */
+void checkSbeState(struct pdbg_target* pib)
+{
 	enum sbe_state state;
-
-	// If the SBE dump is already collected return error
 	if (sbe_get_state(pib, &state)) {
 		log(level::ERROR, "Failed to read SBE state information (%s)",
-				pdbg_target_path(proc));
+		    pdbg_target_path(pib));
 		throw sbeError_t(exception::SBE_STATE_READ_FAIL);
-	
 	}
-
 	if (state == SBE_STATE_FAILED) {
-		log(level::ERROR, "Dump is already collected from the "
-				"SBE on (%s)", pdbg_target_path(proc));
+		log(level::ERROR,
+		    "Dump is already collected from the SBE on (%s)",
+		    pdbg_target_path(pib));
 		throw sbeError_t(exception::SBE_DUMP_IS_ALREADY_COLLECTED);
 	}
+}
 
-	// Execute SBE extract rc to set up sdb bit for pibmem dump to work
-	// TODO Add error handling or revisit procedure later
-	fapi2::ReturnCode fapiRc;
+/**
+ * @brief Executes the SBE extract RC and writes recovery action data.
+ * @param[in] proc The processor target on which to execute the SBE extract RC.
+ * @param[in] dumpPath The filesystem path where the SBE data and recovery
+ * action information will be written.
+ *
+ * @throw std::runtime_error Throws if the SBE extract RC operation fails.
+ */
+void executeSbeExtractRc(struct pdbg_target* proc,
+			 const std::filesystem::path& dumpPath)
+{
 	P10_EXTRACT_SBE_RC::RETURN_ACTION recovAction;
-
-	// p10_extract_sbe_rc is returning the error along with
-	// recovery action, so not checking the fapirc.
-	fapiRc = p10_extract_sbe_rc(proc, recovAction, true);
+	fapi2::ReturnCode fapiRc = p10_extract_sbe_rc(proc, recovAction, true);
 	log(level::INFO,
 	    "p10_extract_sbe_rc for proc=%s returned rc=0x%08X and SBE "
 	    "Recovery Action=0x%08X",
 	    pdbg_target_path(proc), fapiRc, recovAction);
-
 	writeSbeData(dumpPath, fapiRc, recovAction);
-
-	return proc;
 }
 
 /**
- * @brief Write the dump file to the path
- * @param[in] data Pointer to the data buffer
- * @param[in] len Length of the buffer
- * @param[in] dumpPath Path of the file
+ * @brief Writes SBE register values to a file.
+ * @param[in] dumpRegs A vector of `DumpSBERegVal` structures containing the SBE
+ * register values to be written.
+ * @param[in] basePath The filesystem path of the file to which the data is to
+ * be written.
  *
- * Throws FILE_OPERATION_FAILED in the case of error
+ * @throw std::runtime_error Throws if there is an error opening the file or
+ * during the file write operation.
  */
-void writeDumpFile(char* data, size_t len, std::filesystem::path& dumpPath)
+void writeSBERegValuesToFile(const std::vector<DumpSBERegVal>& dumpRegs,
+			     const std::filesystem::path& basePath)
 {
-	log(level::INFO, "writng dump data to file");
-	std::ofstream outfile{dumpPath, std::ios::out | std::ios::binary};
-	if (!outfile.good()) {
-		int err = errno;
-		log(level::ERROR,
-		    "Failed to open the dump file for writing err=%d", err);
-		throw dumpError_t(exception::FILE_OPERATION_FAILED);
-	}
-	outfile.exceptions(std::ifstream::failbit | std::ifstream::badbit |
-			   std::ifstream::eofbit);
 	try {
-		outfile.write(data, len);
-	} catch (const std::ofstream::failure& oe) {
-		int err = errno;
+		std::ofstream outfile{basePath,
+				      std::ios::out | std::ios::binary};
+		if (!outfile.good()) {
+			throw std::runtime_error(
+			    "Failed to open file for writing");
+		}
+		outfile.write(reinterpret_cast<const char*>(dumpRegs.data()),
+			      sizeof(DumpSBERegVal) * dumpRegs.size());
+	} catch (const std::exception& e) {
 		log(level::ERROR,
-		    "Failed to write to dump file err=%d error message=%s", err,
-		    oe.what());
-		throw dumpError_t(exception::FILE_OPERATION_FAILED);
+		    "Error writing SBE register values to file: %s", e.what());
+		throw;
 	}
-	outfile.close();
+}
+
+/**
+ * @brief Collects and writes local register dump data for a given processor
+ * target.
+ *
+ * This function is responsible for collecting the local register dump from the
+ * specified processor target and writing this data to a file. It forms the
+ * complete file path using the provided base filename and dump path. If the
+ * function encounters any errors during the data collection or file writing
+ * process, it throws an exception.
+ *
+ * @param[in] proc The processor target from which to collect the local register
+ * dump.
+ * @param[in] dumpPath The filesystem path where the dump file will be written.
+ * @param[in] baseFilename The base filename to use for the dump file. This name
+ * will be used to form the complete file path along with the dumpPath.
+ *
+ * @throw std::runtime_error Throws if there is an error in collecting the local
+ * register dump or writing to the file.
+ */
+void collectLocalRegDump(struct pdbg_target* proc,
+			 const std::filesystem::path& dumpPath,
+			 const std::string& baseFilename)
+{
+	std::vector<SBESCOMRegValue_t> sbeScomRegValue;
+	ReturnCode fapiRc = p10_sbe_localreg_dump(proc, true, sbeScomRegValue);
+
+	if (fapiRc != FAPI2_RC_SUCCESS) {
+		log(level::ERROR,
+		    "Failed in p10_sbe_localreg_dump for proc=%s, rc=0x%08X",
+		    pdbg_target_path(proc), fapiRc);
+		throw std::runtime_error("p10_sbe_localreg_dump failed");
+	}
+
+	std::vector<DumpSBERegVal> dumpRegs;
+	for (auto& reg : sbeScomRegValue) {
+		dumpRegs.emplace_back(reg.reg.number, reg.reg.name, reg.value);
+	}
+	std::string dumpFilename = baseFilename + "p10_sbe_localreg_dump";
+	std::filesystem::path basePath = dumpPath / dumpFilename;
+
+	// Writing the SBE register values to a file
+	writeSBERegValuesToFile(dumpRegs, basePath);
+}
+
+/**
+ * @brief Writes PIBMS register values to a file.
+ * @param[in] dumpRegs A vector of `DumpPIBMSRegVal` structures containing the
+ * PIBMS register values to be written.
+ * @param[in] basePath The filesystem path of the file to which the data is to
+ * be written.
+ *
+ * @throw std::runtime_error Throws if there is an error opening the file or
+ * during the file write operation.
+ */
+void writePIBMSRegValuesToFile(const std::vector<DumpPIBMSRegVal>& dumpRegs,
+			       const std::filesystem::path& basePath)
+{
+	try {
+		std::ofstream outfile{basePath,
+				      std::ios::out | std::ios::binary};
+		if (!outfile.good()) {
+			throw std::runtime_error(
+			    "Failed to open file for writing");
+		}
+		outfile.write(reinterpret_cast<const char*>(dumpRegs.data()),
+			      sizeof(DumpPIBMSRegVal) * dumpRegs.size());
+	} catch (const std::exception& e) {
+		log(level::ERROR,
+		    "Error writing PIBMS register values to file: %s",
+		    e.what());
+		throw;
+	}
+}
+
+/**
+ * @brief Collects and writes PIBMS register dump data for a given processor
+ * target.
+ * @param[in] proc The processor target from which to collect the PIBMS register
+ * dump.
+ * @param[in] dumpPath The filesystem path where the dump file will be written.
+ * @param[in] baseFilename The base filename to use for the dump file. This name
+ * will be used to form the complete file path along with the dumpPath.
+ *
+ * @throw std::runtime_error Throws if there is an error in collecting the PIBMS
+ * register dump or writing to the file.
+ */
+void collectPIBMSRegDump(struct pdbg_target* proc,
+			 const std::filesystem::path& dumpPath,
+			 const std::string& baseFilename)
+{
+	std::vector<sRegV> pibmsRegSet;
+	for (auto& reg : pibms_regs_2dump) {
+		sRegV regv;
+		regv.reg = reg;
+		pibmsRegSet.emplace_back(regv);
+	}
+
+	ReturnCode fapiRc = p10_pibms_reg_dump(proc, pibmsRegSet);
+	if (fapiRc != FAPI2_RC_SUCCESS) {
+		log(level::ERROR,
+		    "Failed in p10_pibms_reg_dump for proc=%s, rc=0x%08X",
+		    pdbg_target_path(proc), fapiRc);
+		throw std::runtime_error("p10_pibms_reg_dump failed");
+	}
+	std::vector<DumpPIBMSRegVal> dumpRegs;
+	for (auto& reg : pibmsRegSet) {
+		dumpRegs.emplace_back(reg.reg.addr, reg.reg.name, reg.reg.attr,
+				      reg.value);
+	}
+
+	std::string dumpFilename = baseFilename + "p10_pibms_reg_dump";
+	std::filesystem::path basePath = dumpPath / dumpFilename;
+
+	// Writing the PIBMS register values to a file
+	writePIBMSRegValuesToFile(dumpRegs, basePath);
+}
+
+/**
+ * @brief Writes PIBMEM data to a file.
+ * @param[in] dumpData A vector of uint64_t values representing the PIBMEM data
+ * to be written.
+ * @param[in] basePath The filesystem path of the file to which the data will be
+ * written.
+ *
+ * @throw std::runtime_error Throws if there is an error opening the file or
+ * during the file write operation.
+ */
+void writePIBMEMDataToFile(const std::vector<uint64_t>& dumpData,
+			   const std::filesystem::path& basePath)
+{
+	try {
+		std::ofstream outfile{basePath,
+				      std::ios::out | std::ios::binary};
+		if (!outfile.good()) {
+			throw std::runtime_error(
+			    "Failed to open file for writing");
+		}
+		outfile.write(reinterpret_cast<const char*>(dumpData.data()),
+			      sizeof(uint64_t) * dumpData.size());
+	} catch (const std::exception& e) {
+		log(level::ERROR, "Error writing PIBMEM data to file: %s",
+		    e.what());
+		throw;
+	}
+}
+
+/**
+ * @brief Collects and writes PIBMEM dump data for a given processor target.
+ * @param[in] proc The processor target from which to collect the PIBMEM dump
+ * data.
+ * @param[in] dumpPath The filesystem path where the dump file will be written.
+ * @param[in] baseFilename The base filename to use for the dump file. This name
+ * will be used to form the complete file path along with the dumpPath.
+ *
+ * @throw std::runtime_error Throws if there is an error in collecting the
+ * PIBMEM dump data or writing to the file.
+ */
+void collectPIBMEMDump(struct pdbg_target* proc,
+		       const std::filesystem::path& dumpPath,
+		       const std::string& baseFilename)
+{
+	// Define these constants and types as per your requirement
+	const uint32_t pibmemDumpStartByte = 0;	      // Starting byte for dump
+	const uint32_t pibmemDumpNumOfByte = 0x7D400; // Number of bytes to read
+	const user_options userOptions =
+	    INTERMEDIATE_TILL_INTERMEDIATE; // User options, define as per your
+					    // code
+	const bool eccEnable = false; // ECC enabled/disabled
+
+	std::vector<array_data_t>
+	    pibmemContents; // Type array_data_t should be defined in your code
+
+	ReturnCode fapiRc =
+	    p10_pibmem_dump(proc, pibmemDumpStartByte, pibmemDumpNumOfByte,
+			    userOptions, pibmemContents, eccEnable);
+	if (fapiRc != FAPI2_RC_SUCCESS) {
+		log(level::ERROR,
+		    "Failed in p10_pibmem_dump for proc=%s, rc=0x%08X",
+		    pdbg_target_path(proc), fapiRc);
+		throw std::runtime_error("p10_pibmem_dump failed");
+	}
+	std::vector<uint64_t> dumpData;
+	for (auto& data : pibmemContents) {
+		dumpData.push_back(data.read_data);
+	}
+
+	std::string dumpFilename = baseFilename + "p10_pibmem_dump";
+	std::filesystem::path basePath = dumpPath / dumpFilename;
+
+	// Writing the PIBMEM data to a file
+	writePIBMEMDataToFile(dumpData, basePath);
+}
+
+/**
+ * @brief Writes PPE (Programmable Processing Element) state data to a file.
+ * @param[in] ppeState A vector of `DumpPPERegValue` structures containing the
+ * PPE state data to be written.
+ * @param[in] basePath The filesystem path of the file to which the data will be
+ * written.
+ *
+ * @throw std::runtime_error Throws if there is an error opening the file or
+ * during the file write operation.
+ */
+void writePPEStateToFile(const std::vector<DumpPPERegValue>& ppeState,
+			 const std::filesystem::path& basePath)
+{
+	try {
+		std::ofstream outfile{basePath,
+				      std::ios::out | std::ios::binary};
+		if (!outfile.good()) {
+			throw std::runtime_error(
+			    "Failed to open file for writing");
+		}
+		outfile.write(reinterpret_cast<const char*>(ppeState.data()),
+			      sizeof(DumpPPERegValue) * ppeState.size());
+	} catch (const std::exception& e) {
+		log(level::ERROR, "Error writing PPE state data to file: %s",
+		    e.what());
+		throw;
+	}
+}
+
+/**
+ * @brief Collects and writes the state of the Programmable Processing Element
+ * (PPE).
+ * @param[in] proc The processor target from which to collect the PPE state.
+ * @param[in] dumpPath The filesystem path where the dump file will be written.
+ * @param[in] baseFilename The base filename to use for the dump file. This name
+ * will be used to form the complete file path along with the dumpPath.
+ *
+ * @throw std::runtime_error Throws if there is an error in collecting the PPE
+ * state or writing to the file.
+ */
+void collectPPEState(struct pdbg_target* proc,
+		     const std::filesystem::path& dumpPath,
+		     const std::string& baseFilename)
+{
+	PPE_DUMP_MODE mode = SNAPSHOT; // Define as per your requirement
+	uint32_t instanceNum = 0;      // Instance number, set as needed
+	PPE_TYPES type =
+	    PPE_TYPE_SBE; // Set the PPE type as per your requirement
+
+	std::vector<Reg32Value_t> ppeGprsValue, ppeSprsValue, ppeXirsValue;
+
+	ReturnCode fapiRc =
+	    p10_ppe_state(proc, type, instanceNum, mode, ppeGprsValue,
+			  ppeSprsValue, ppeXirsValue);
+	if (fapiRc != FAPI2_RC_SUCCESS) {
+		log(level::ERROR,
+		    "Failed in p10_ppe_state for proc=%s, rc=0x%08X",
+		    pdbg_target_path(proc), fapiRc);
+		throw std::runtime_error("p10_ppe_state failed");
+	}
+
+	std::vector<DumpPPERegValue> ppeState;
+	for (auto& spr : ppeSprsValue) {
+		ppeState.emplace_back(spr.number, spr.value);
+	}
+	for (auto& xir : ppeXirsValue) {
+		ppeState.emplace_back(xir.number, xir.value);
+	}
+	for (auto& gpr : ppeGprsValue) {
+		ppeState.emplace_back(gpr.number, gpr.value);
+	}
+
+	std::string dumpFilename = baseFilename + "p10_ppe_state";
+	std::filesystem::path basePath = dumpPath / dumpFilename;
+
+	// Writing the PPE state data to a file
+	writePPEStateToFile(ppeState, basePath);
+}
+
+/**
+ * @brief Finalizes the collection process.
+ * @param[in] pib The PIB target for which the collection is being finalized.
+ * @param[in] dumpPath The filesystem path where the dump was written. Used for
+ * cleanup in case of failure.
+ * @param[in] isSuccess A boolean flag indicating whether the preceding
+ * collection steps were successful.
+ */
+void finalizeCollection(struct pdbg_target* pib,
+			const std::filesystem::path& dumpPath, bool isSuccess)
+{
+	// Attempt to set the SBE state to the final state (e.g., FAILED)
+	if (0 > sbe_set_state(pib, SBE_STATE_FAILED)) {
+		log(level::ERROR, "Failed to set SBE state to FAILED");
+		// Handle error if needed
+	}
+
+	// If the collection was not successful, clean up partial data
+	if (!isSuccess) {
+		try {
+			std::filesystem::remove_all(dumpPath);
+			log(level::INFO, "Cleaned up partial dump data due to "
+					 "collection failure");
+		} catch (const std::exception& e) {
+			log(level::ERROR,
+			    "Error cleaning up partial dump data: %s",
+			    e.what());
+		}
+	}
+
+	log(level::INFO, "Collection process completed");
 }
 
 void collectSBEDump(uint32_t id, uint32_t failingUnit,
 		    const std::filesystem::path& dumpPath, const int sbeTypeId)
 {
-	if (sbeTypeId != static_cast<uint16_t>(10))
+	if (sbeTypeId != static_cast<uint16_t>(10)) {
 		throw dumpError_t(exception::HWP_EXECUTION_FAILED);
+	}
 
 	log(level::INFO,
-		"Collecting SBE dump: path=%s, id=%d, chip position=%d",
-		dumpPath.string().c_str(), id, failingUnit);
+	    "Collecting SBE dump: path=%s, id=%d, chip position=%d",
+	    dumpPath.string().c_str(), id, failingUnit);
 
 	std::stringstream ss;
 	ss << std::setw(8) << std::setfill('0') << id;
-
-	// Filename format
-	// <dumpID>.<nodeNUM>_<procNum>.Sbedata_p10_<HWP name>
 	std::string baseFilename =
 	    ss.str() + ".0_" + std::to_string(failingUnit) + "_SbeData_p10_";
 
-	// Execute pre-collection and get proc corresponding to failing unit
-	struct pdbg_target* proc = preCollection(failingUnit, dumpPath);
-
-	// Get pib for the proc
-	struct pdbg_target* pib = getPibTarget(proc);
-
-	// Set SBE state to SBE_STATE_DEBUG_MODE
-	if (0 > sbe_set_state(pib, SBE_STATE_DEBUG_MODE)) {
-		log(level::ERROR, "Setting SBE state to debug mode failed");
-		throw std::runtime_error(
-		    "Setting SBE state to debug mode failed");
-	}
-
-	fapi2::ReturnCode fapiRc;
+	struct pdbg_target* proc = nullptr;
+	struct pdbg_target* pib = nullptr;
 
 	try {
-		// Collect SBE local register dump
-		std::vector<SBESCOMRegValue_t> sbeScomRegValue;
-		fapiRc = p10_sbe_localreg_dump(proc, true, sbeScomRegValue);
-		if (fapiRc != fapi2::FAPI2_RC_SUCCESS) {
-			log(level::ERROR,
-			    "Failed in p10_sbe_localreg_dump for proc=%s, "
-			    "rc=0x%08X",
-			    pdbg_target_path(proc), fapiRc);
-		} else {
-			std::vector<DumpSBERegVal> dumpRegs;
-			for (auto& reg : sbeScomRegValue) {
-				dumpRegs.emplace_back(reg.reg.number,
-						      reg.reg.name, reg.value);
-			}
-			std::string dumpFilename =
-			    baseFilename + "p10_sbe_localreg_dump";
-			std::filesystem::path basePath =
-			    dumpPath / dumpFilename;
+		// Execute pre-collection steps and get the proc target
+		initializePdbgLibEkb();
 
-			try {
-				writeDumpFile(
-				    reinterpret_cast<char*>(&dumpRegs[0]),
-				    sizeof(DumpSBERegVal) * dumpRegs.size(),
-				    basePath);
-			} catch (const dumpError_t& e) {
-				log(level::ERROR,
-				    "Error in writing p10_sbe_localreg_dump "
-				    "file "
-				    "errorMsg=%s",
-				    e.what());
-				throw;
-			}
-		}
+		proc = getProcFromFailingId(failingUnit);
+		probeTarget(proc, "fsi");
+		pib = probeTarget(proc, "pib");
 
-		// Dump contents of various PIB Masters and Slaves internal
-		// registers
-		std::vector<sRegV> pibmsRegSet;
-		for (auto& reg : pibms_regs_2dump) {
-			sRegV regv;
-			regv.reg = reg;
-			pibmsRegSet.emplace_back(regv);
-		}
+		checkSbeState(pib);
+		executeSbeExtractRc(proc, dumpPath);
 
-		fapiRc = p10_pibms_reg_dump(proc, pibmsRegSet);
-		if (fapiRc != fapi2::FAPI2_RC_SUCCESS) {
-			log(level::ERROR,
-			    "Failed in p10_pibms_reg_dump for proc=%s, "
-			    "rc=0x%08X",
-			    pdbg_target_path(proc), fapiRc);
-		} else {
-			std::vector<DumpPIBMSRegVal> dumpRegs;
-			for (sRegV& regs : pibmsRegSet) {
-				dumpRegs.emplace_back(
-				    regs.reg.addr, regs.reg.name, regs.reg.attr,
-				    regs.value);
-			}
-			std::string dumpFilename =
-			    baseFilename + "p10_pibms_reg_dump";
-			std::filesystem::path basePath =
-			    dumpPath / dumpFilename;
-			try {
-				writeDumpFile(
-				    reinterpret_cast<char*>(&dumpRegs[0]),
-				    sizeof(DumpPIBMSRegVal) * dumpRegs.size(),
-				    basePath);
-			} catch (const dumpError_t& e) {
-				log(level::ERROR,
-				    "Error in writing p10_pibms_reg_dump file, "
-				    "errorMsg=%s",
-				    e.what());
-				throw;
-			}
-		}
+		// Collect various dumps
+		collectLocalRegDump(proc, dumpPath, baseFilename);
+		collectPIBMSRegDump(proc, dumpPath, baseFilename);
+		collectPIBMEMDump(proc, dumpPath, baseFilename);
+		collectPPEState(proc, dumpPath, baseFilename);
 
-		// Dump the PIBMEM Array based on starting and number of address
-		std::vector<array_data_t> pibmemContents;
-		bool eccEnable = false;
-		uint32_t pibmemDumpStartByte = 0;
-		// Number of bytes to be read from PIBMEM
-		static constexpr uint32_t pibmemDumpNumOfByte = 0x7D400;
-		user_options userOptions = INTERMEDIATE_TILL_INTERMEDIATE;
-
-		fapiRc = p10_pibmem_dump(proc, pibmemDumpStartByte,
-					 pibmemDumpNumOfByte, userOptions,
-					 pibmemContents, eccEnable);
-		if (fapiRc != fapi2::FAPI2_RC_SUCCESS) {
-			log(level::ERROR,
-			    "Failed in p10_pibmem_dump for proc=%s, rc=0x%08X",
-			    pdbg_target_path(proc), fapiRc);
-		} else {
-			std::vector<uint64_t> dumpData;
-			for (auto& data : pibmemContents) {
-				dumpData.push_back(data.read_data);
-			}
-			std::string dumpFilename =
-			    baseFilename + "p10_pibmem_dump";
-			std::filesystem::path basePath =
-			    dumpPath / dumpFilename;
-			try {
-				writeDumpFile(
-				    reinterpret_cast<char*>(&dumpData[0]),
-				    sizeof(uint64_t) * dumpData.size(),
-				    basePath);
-			} catch (const dumpError_t& e) {
-				log(level::ERROR,
-				    "Error in writing p10_pibmem_dump file "
-				    "errorMsg=%s",
-				    e.what());
-				throw;
-			}
-		}
-
-		// Dump the PPE state based on the based base address
-		PPE_DUMP_MODE mode = SNAPSHOT;
-		uint32_t instanceNum = 0;
-		std::vector<Reg32Value_t> ppeGprsValue;
-		std::vector<Reg32Value_t> ppeSprsValue;
-		std::vector<Reg32Value_t> ppeXirsValue;
-		PPE_TYPES type = PPE_TYPE_SBE;
-
-		fapiRc =
-		    p10_ppe_state(proc, type, instanceNum, mode, ppeGprsValue,
-				  ppeSprsValue, ppeXirsValue);
-		if (fapiRc != fapi2::FAPI2_RC_SUCCESS) {
-			log(level::ERROR,
-			    "Failed in p10_ppe_state for proc=%s, rc=0x%08X",
-			    pdbg_target_path(proc), fapiRc);
-		} else {
-			std::vector<DumpPPERegValue> ppeState;
-			for (auto& spr : ppeSprsValue) {
-				ppeState.emplace_back(spr.number, spr.value);
-			}
-			for (auto& xir : ppeXirsValue) {
-				ppeState.emplace_back(xir.number, xir.value);
-			}
-			for (auto& gpr : ppeGprsValue) {
-				ppeState.emplace_back(gpr.number, gpr.value);
-			}
-
-			std::string dumpFilename =
-			    baseFilename + "p10_ppe_state";
-			std::filesystem::path basePath =
-			    dumpPath / dumpFilename;
-			try {
-				writeDumpFile(
-				    reinterpret_cast<char*>(&ppeState[0]),
-				    sizeof(DumpPPERegValue) * ppeState.size(),
-				    basePath);
-			} catch (const dumpError_t& e) {
-				log(level::ERROR,
-				    "Error in writing p10_ppe_state file, "
-				    "errorMsg=%s",
-				    e.what());
-				throw;
-			}
-		}
+		// Finalize the collection process
+		finalizeCollection(pib, dumpPath,
+				   true); // Indicate successful completion
+		log(level::INFO, "SBE dump collection completed successfully");
 	} catch (const std::exception& e) {
-		log(level::ERROR, "Failed to collect the SBE dump");
-		if (0 > sbe_set_state(pib, SBE_STATE_FAILED)) {
-			log(level::ERROR, "Failed to set SBE state to FAILED");
+		log(level::ERROR, "Failed to collect the SBE dump: %s",
+		    e.what());
+		// In case of any exception, attempt to finalize with a failure
+		// state
+		if (proc) {
+			pib = getPibTarget(proc);
+			finalizeCollection(pib, dumpPath, false);
 		}
-		// Dump collection failed remove the directory
-		// and partial contents
-		std::filesystem::remove_all(dumpPath);
-		// Rethrow the exception
 		throw;
 	}
-
-	// Set SBE state to SBE_STATE_FAILED
-	if (0 > sbe_set_state(pib, SBE_STATE_FAILED)) {
-		log(level::ERROR, "Failed to set SBE state to FAILED");
-	}
-	log(level::INFO, "SBE dump collected");
 }
+
 } // namespace dump
 } // namespace openpower::phal


### PR DESCRIPTION
This commit breaks down the large functions involved in the SBE dump collection process into smaller, more manageable functions.

Changes:
- Split preCollection to smaller functions
- collectSBEDump calls each of these smaller functions.
- Split collect dump to smaller functions for executing each HWP The refactor does not introduce any new functionality

Tests
root@ever6bmc:~# busctl --verbose call org.open_power.Dump.Manager /org/openpower/dump xyz.openbmc_project.Dump.Create CreateDump a{sv} 3  "com.ibm.Dump.Create.CreateParameters.DumpType" s "com.ibm.Dump.Create.DumpType.SBE" "com.ibm.Dump.Create.CreateParameters.ErrorLogId" t 0xDEADBEEF "com.ibm.Dump.Create.CreateParameters.FailingUnitId" t 2
MESSAGE "o" {
        OBJECT_PATH "/xyz/openbmc_project/dump/sbe/entry/30000003";
};

Jan 16 15:30:44 ever6bmc phosphor-dump-manager[7249]: plat_dump/30000003.0_2_SbeData_p10_p10_pibmem_dump
Jan 16 15:30:44 ever6bmc phosphor-dump-manager[7249]: plat_dump/30000003.0_2_SbeData_p10_p10_pibms_reg_dump
Jan 16 15:30:44 ever6bmc phosphor-dump-manager[7249]: plat_dump/30000003.0_2_SbeData_p10_p10_ppe_state
Jan 16 15:30:44 ever6bmc phosphor-dump-manager[7249]: plat_dump/30000003.0_2_SbeData_p10_p10_sbe_localreg_dump
Jan 16 15:30:44 ever6bmc phosphor-dump-manager[7249]: info.yaml
Jan 16 15:30:44 ever6bmc phosphor-dump-manager[7219]: Adding Dump Header :/usr/share/dreport.d/include.d/gendumpheader


root@ever6bmc:~# busctl --verbose call org.open_power.Dump.Manager /org/openpower/dump xyz.openbmc_project.Dump.Create CreateDump a{sv} 3  "com.ibm.Dump.Create.CreateParameters.DumpType" s "com.ibm.Dump.Create.DumpType.SBE" "com.ibm.Dump.Create.CreateParameters.ErrorLogId" t 0xDEADBEEF "com.ibm.Dump.Create.CreateParameters.FailingUnitId" t 1
MESSAGE "o" {
        OBJECT_PATH "/xyz/openbmc_project/dump/sbe/entry/30000005";
};


Jan 16 15:34:15 ever6bmc phosphor-dump-manager[7941]: Collecting SBE dump: path=/tmp/dump_30000005_1705419255/plat_dump, id=30000005, chip position=1
Jan 16 15:34:15 ever6bmc phosphor-dump-manager[7941]: PDBG Initilization started
Jan 16 15:34:15 ever6bmc phosphor-dump-manager[7941]: Dump is already collected from the SBE on (/proc1/pib)
Jan 16 15:34:15 ever6bmc phosphor-dump-manager[7941]: Failed to collect the SBE dump: Dump from this SBE is already collected
Jan 16 15:34:15 ever6bmc phosphor-dump-manager[7941]: Cleaned up partial dump data due to collection failure
Jan 16 15:34:15 ever6bmc phosphor-dump-manager[7941]: Collection process completed
Jan 16 15:34:15 ever6bmc phosphor-dump-manager[7941]: Dump from this SBE is already collected
Jan 16 15:34:15 ever6bmc phosphor-dump-manager[7929]: Tue Jan 16 15:34:15 UTC 2024 Error: Failed to collect dump, Exiting