### PR TITLE
Odyssey SBE dump collection support code added

### DIFF
--- a/libphal/phal_dump.C
+++ b/libphal/phal_dump.C
@@ -19,6 +19,12 @@ extern "C" {
 #include <ekb/chips/p10/procedures/hwp/lib/p10_ppe_state.H>
 #include <ekb/chips/p10/procedures/hwp/lib/p10_sbe_localreg_dump.H>
 #include <ekb/chips/p10/procedures/hwp/perv/p10_extract_sbe_rc.H>
+#include <ekb/chips/ocmb/odyssey/procedures/hwp/utils/ody_sbe_localreg_dump.H>
+#include <ekb/chips/ocmb/odyssey/procedures/hwp/utils/ody_pibms_regs2dump.H>
+#include <ekb/chips/ocmb/odyssey/procedures/hwp/utils/ody_pibmem_dump.H>
+#include <ekb/chips/ocmb/odyssey/procedures/hwp/utils/ody_pibms_reg_dump.H>
+#include <ekb/chips/ocmb/odyssey/procedures/hwp/utils/ody_ppe_state.H>
+#include <ekb/chips/ocmb/odyssey/procedures/hwp/perv/ody_extract_sbe_rc.H>
 
 #include <filesystem>
 #include <fstream>
@@ -99,37 +105,82 @@ struct DumpPPERegValue {
 	}
 } __attribute__((packed));
 
+// Define the chip types numbers
+static constexpr int PROC_SBE_DUMP = 0xA;
+static constexpr int ODYSSEY_SBE_DUMP = 0xB;
+
 /**
- * @brief Return the proc target corresponding to failing unit
- * @param[in] failingUnit Position of the proc containing the failed SBE
+ * @brief Get the Fapi Unit Pos object for OCMB
  *
- * @return Pointer to the pdbg target for proc
+ * @param target The target
+ * @return uint8_t The position
+ */
+uint32_t getFapiUnitPos(pdbg_target* target)
+{
+	uint32_t fapiUnitPos = 0; // chip unit position
+	if (!pdbg_target_get_attribute(target, "ATTR_FAPI_POS", 4, 1,
+				       &fapiUnitPos))
+		log(level::ERROR, "ATTR_FAPI_POS Attribute get failed");
+
+	return fapiUnitPos;
+}
+
+/**
+ * @brief Return the chip target corresponding to failing unit
+ * @param[in] failingUnit Position of the ocmb containing the failed SBE
+ * @param sbeTypeId The chip type number
+ *
+ * @return Pointer to the pdbg target for retreived chip
  *
  * Exceptions: PDBG_TARGET_NOT_OPERATIONAL if target is not available
  */
-struct pdbg_target* getProcFromFailingId(const uint32_t failingUnit)
+struct pdbg_target* getTargetFromFailingId(const uint32_t failingUnit,
+					   const int sbeTypeId)
 {
-	struct pdbg_target* proc = NULL;
+	struct pdbg_target* chip = nullptr;
 	struct pdbg_target* target;
-	pdbg_for_each_class_target("proc", target)
+	std::string chipTypeString;
+
+	if (sbeTypeId == ODYSSEY_SBE_DUMP)
+		chipTypeString = "ocmb";
+	else if (sbeTypeId == PROC_SBE_DUMP)
+		chipTypeString = "proc";
+
+	pdbg_for_each_class_target(chipTypeString.c_str(), target)
 	{
-		if (pdbg_target_index(target) != failingUnit) {
+		uint8_t targetIdx = 0;
+		if (sbeTypeId == ODYSSEY_SBE_DUMP)
+			targetIdx = getFapiUnitPos(target);
+		else if (sbeTypeId == PROC_SBE_DUMP)
+			targetIdx = pdbg_target_index(target);
+
+		if (targetIdx != failingUnit) {
 			continue;
 		}
-
+		if (sbeTypeId == ODYSSEY_SBE_DUMP) {
+			if (!openpower::phal::sbe::is_ody_ocmb_chip(target)) {
+				log(level::ERROR,
+				    "No ocmb target found to execute the dump "
+				    "for failing unit=%d",
+				    failingUnit);
+				throw sbeError_t(
+				    exception::PDBG_TARGET_NOT_OPERATIONAL);
+			}
+		}
 		if (pdbg_target_probe(target) != PDBG_TARGET_ENABLED) {
 			break;
 		}
-		proc = target;
+		chip = target;
+		break;
 	}
-	if (proc == NULL) {
+	if (!chip) {
 		log(level::ERROR,
-		    "No Proc target found to execute the dump for failing "
+		    "No chip target found to execute the dump for failing "
 		    "unit=%d",
 		    failingUnit);
 		throw sbeError_t(exception::PDBG_TARGET_NOT_OPERATIONAL);
 	}
-	return proc;
+	return chip;
 }
 
 /**
@@ -185,68 +236,121 @@ void initializePdbgLibEkb()
 
 /**
  * @brief Probes a target (FSI or PIB) for the given processor target.
- * @param[in] proc The processor target to probe the FSI/PIB target for.
+ * @param[in] proc The processor or Odyssey target to probe the FSI/PIB target
+ * for.
  * @param[in] targetType The type of target to probe ("fsi" or "pib").
+ * @param[in] sbeTypeId The chip type ID
  * @return Pointer to the probed pdbg target. If the target is not operational,
  *         the function throws an exception.
  *
  * @throw dumpError_t Throws if the target is not found or not operational.
  */
 struct pdbg_target* probeTarget(struct pdbg_target* proc,
-				const char* targetType)
+				const char* targetType, const int sbeTypeId)
 {
-	char path[16];
-	sprintf(path, "/proc%d/%s", pdbg_target_index(proc), targetType);
-	struct pdbg_target* target = pdbg_target_from_path(NULL, path);
-	if (!target || pdbg_target_probe(target) != PDBG_TARGET_ENABLED) {
-		log(level::ERROR, "Failed to get or probe %s target for (%s)",
-		    targetType, pdbg_target_path(proc));
-		throw dumpError_t(exception::PDBG_TARGET_NOT_OPERATIONAL);
+	if (sbeTypeId == PROC_SBE_DUMP) {
+		char path[16];
+		sprintf(path, "/proc%d/%s", pdbg_target_index(proc),
+			targetType);
+		struct pdbg_target* target = pdbg_target_from_path(NULL, path);
+		if (!target ||
+		    pdbg_target_probe(target) != PDBG_TARGET_ENABLED) {
+			log(level::ERROR,
+			    "Failed to get or probe %s target for (%s)",
+			    targetType, pdbg_target_path(proc));
+			throw dumpError_t(
+			    exception::PDBG_TARGET_NOT_OPERATIONAL);
+		}
+		return target;
+	} else if (sbeTypeId == ODYSSEY_SBE_DUMP) {
+		struct pdbg_target* target = nullptr;
+		if (0 == std::string("pib").compare(targetType))
+			target = get_ody_pib_target(proc);
+		else
+			target = get_ody_fsi_target(proc);
+
+		if (!target) {
+			log(level::ERROR, "Failed to get %s target for(%s)",
+			    targetType, pdbg_target_path(target));
+			throw dumpError_t(
+			    exception::PDBG_TARGET_NOT_OPERATIONAL);
+		}
+		// Probe target for HWP execution
+		if (pdbg_target_probe(target) != PDBG_TARGET_ENABLED) {
+			log(level::ERROR, "Failed to prob %s", targetType);
+			throw dumpError_t(
+			    exception::PDBG_TARGET_NOT_OPERATIONAL);
+		}
+		return target;
+	} else {
+		return nullptr;
 	}
-	return target;
 }
 
 /**
  * @brief Checks the state of the SBE on the given PIB target.
- * @param[in] pib The PIB target to check the SBE state of.
+ * @param[in] pib_fsi The PIB or FSI target to check the SBE state of.
+ * @param[in] sbeTypeId The chip type ID
  *
  * @throw sbeError_t Throws if the SBE state is 'FAILED' (indicating a dump
  *        has already been collected) or if there is a failure in reading the
  * SBE state.
  */
-void checkSbeState(struct pdbg_target* pib)
+void checkSbeState(struct pdbg_target* pib_fsi, const int sbeTypeId)
 {
 	enum sbe_state state;
-	if (sbe_get_state(pib, &state)) {
+	auto rv = -1;
+	if (PROC_SBE_DUMP == sbeTypeId)
+		rv = sbe_get_state(pib_fsi, &state);
+	else if (ODYSSEY_SBE_DUMP == sbeTypeId)
+		rv = sbe_ody_get_state(pib_fsi, &state);
+
+	if (rv) {
 		log(level::ERROR, "Failed to read SBE state information (%s)",
-		    pdbg_target_path(pib));
+		    pdbg_target_path(pib_fsi));
 		throw sbeError_t(exception::SBE_STATE_READ_FAIL);
 	}
 	if (state == SBE_STATE_FAILED) {
 		log(level::ERROR,
 		    "Dump is already collected from the SBE on (%s)",
-		    pdbg_target_path(pib));
+		    pdbg_target_path(pib_fsi));
 		throw sbeError_t(exception::SBE_DUMP_IS_ALREADY_COLLECTED);
 	}
 }
 
 /**
  * @brief Executes the SBE extract RC and writes recovery action data.
- * @param[in] proc The processor target on which to execute the SBE extract RC.
+ * @param[in] target The processor/odyssey target on which to execute the SBE
+ * extract RC.
  * @param[in] dumpPath The filesystem path where the SBE data and recovery
  * action information will be written.
+ * @param sbeTypeId[in] The chip type, i.e.; proc or OCMB
  *
  * @throw std::runtime_error Throws if the SBE extract RC operation fails.
  */
-void executeSbeExtractRc(struct pdbg_target* proc,
-			 const std::filesystem::path& dumpPath)
+void executeSbeExtractRc(struct pdbg_target* target,
+			 const std::filesystem::path& dumpPath,
+			 const int sbeTypeId)
 {
-	P10_EXTRACT_SBE_RC::RETURN_ACTION recovAction;
-	fapi2::ReturnCode fapiRc = p10_extract_sbe_rc(proc, recovAction, true);
+	// Execute SBE extract rc to set up sdb bit for pibmem dump to work
+	P10_EXTRACT_SBE_RC::RETURN_ACTION recovAction = {};
+	std::string targetTypeString;
+	ReturnCode fapiRc;
+
+	if (ODYSSEY_SBE_DUMP == sbeTypeId) {
+		// ody_extract_sbe_rc is returning the error.
+		fapiRc = ody_extract_sbe_rc(target);
+		targetTypeString = "ocmb";
+	} else if (PROC_SBE_DUMP == sbeTypeId) {
+		// p10_extract_sbe_rc is returning the error along with
+		// recovery action, so not checking the fapirc.
+		fapiRc = p10_extract_sbe_rc(target, recovAction, true);
+		targetTypeString = "proc";
+	}
 	log(level::INFO,
-	    "p10_extract_sbe_rc for proc=%s returned rc=0x%08X and SBE "
+	    "extract_sbe_rc for target=%s returned rc=0x%08X and SBE "
 	    "Recovery Action=0x%08X",
-	    pdbg_target_path(proc), fapiRc, recovAction);
+	    pdbg_target_path(target), fapiRc, recovAction);
 	writeSbeData(dumpPath, fapiRc, recovAction);
 }
 
@@ -289,36 +393,53 @@ void writeSBERegValuesToFile(const std::vector<DumpSBERegVal>& dumpRegs,
  * function encounters any errors during the data collection or file writing
  * process, it throws an exception.
  *
- * @param[in] proc The processor target from which to collect the local register
- * dump.
+ * @param[in] target The processor or Odyssey target from which to collect the
+ * local register dump.
  * @param[in] dumpPath The filesystem path where the dump file will be written.
  * @param[in] baseFilename The base filename to use for the dump file. This name
  * will be used to form the complete file path along with the dumpPath.
+ * @param sbeTypeId[in] Chip type ID
  *
  * @throw std::runtime_error Throws if there is an error in collecting the local
  * register dump or writing to the file.
  */
-void collectLocalRegDump(struct pdbg_target* proc,
+void collectLocalRegDump(struct pdbg_target* target,
 			 const std::filesystem::path& dumpPath,
-			 const std::string& baseFilename)
+			 const std::string& baseFilename, const int sbeTypeId)
 {
+	// Collect SBE local register dump
 	std::vector<SBESCOMRegValue_t> sbeScomRegValue;
-	ReturnCode fapiRc = p10_sbe_localreg_dump(proc, true, sbeScomRegValue);
+	std::vector<SBE_SCOMReg_Value_t> sbeScomRegValueOdy;
+	std::string hwpName;
+	ReturnCode fapiRc;
 
+	if (ODYSSEY_SBE_DUMP == sbeTypeId) {
+		hwpName = "ody_sbe_localreg_dump";
+		fapiRc =
+		    ody_sbe_localreg_dump(target, true, sbeScomRegValueOdy);
+	} else if (PROC_SBE_DUMP == sbeTypeId) {
+		hwpName = "p10_sbe_localreg_dump";
+		fapiRc = p10_sbe_localreg_dump(target, true, sbeScomRegValue);
+	}
 	if (fapiRc != FAPI2_RC_SUCCESS) {
-		log(level::ERROR,
-		    "Failed in p10_sbe_localreg_dump for proc=%s, rc=0x%08X",
-		    pdbg_target_path(proc), fapiRc);
-		throw std::runtime_error("p10_sbe_localreg_dump failed");
+		log(level::ERROR, "Failed in %s for proc=%s, rc=0x%08X", target,
+		    pdbg_target_path(target), fapiRc);
+		throw std::runtime_error(hwpName + " failed");
 	}
-
 	std::vector<DumpSBERegVal> dumpRegs;
-	for (auto& reg : sbeScomRegValue) {
-		dumpRegs.emplace_back(reg.reg.number, reg.reg.name, reg.value);
+	// As both sbeScomRegValueOdy and sbeScomRegValue can not have data
+	// at the same time thus
+	if (!sbeScomRegValueOdy.empty()) {
+		for (auto& reg : sbeScomRegValueOdy)
+			dumpRegs.emplace_back(reg.reg.number, reg.reg.name,
+					      reg.value);
+	} else if (!sbeScomRegValue.empty()) {
+		for (auto& reg : sbeScomRegValue)
+			dumpRegs.emplace_back(reg.reg.number, reg.reg.name,
+					      reg.value);
 	}
-	std::string dumpFilename = baseFilename + "p10_sbe_localreg_dump";
+	std::string dumpFilename = baseFilename + hwpName;
 	std::filesystem::path basePath = dumpPath / dumpFilename;
-
 	// Writing the SBE register values to a file
 	writeSBERegValuesToFile(dumpRegs, basePath);
 }
@@ -356,40 +477,62 @@ void writePIBMSRegValuesToFile(const std::vector<DumpPIBMSRegVal>& dumpRegs,
 /**
  * @brief Collects and writes PIBMS register dump data for a given processor
  * target.
- * @param[in] proc The processor target from which to collect the PIBMS register
- * dump.
+ * @param[in] target The processor or odyssey target from which to collect the
+ * PIBMS register dump.
  * @param[in] dumpPath The filesystem path where the dump file will be written.
  * @param[in] baseFilename The base filename to use for the dump file. This name
+ * @param sbeTypeId[in] Chip type ID
  * will be used to form the complete file path along with the dumpPath.
  *
  * @throw std::runtime_error Throws if there is an error in collecting the PIBMS
  * register dump or writing to the file.
  */
-void collectPIBMSRegDump(struct pdbg_target* proc,
+void collectPIBMSRegDump(struct pdbg_target* target,
 			 const std::filesystem::path& dumpPath,
-			 const std::string& baseFilename)
+			 const std::string& baseFilename, const int sbeTypeId)
 {
 	std::vector<sRegV> pibmsRegSet;
-	for (auto& reg : pibms_regs_2dump) {
-		sRegV regv;
-		regv.reg = reg;
-		pibmsRegSet.emplace_back(regv);
-	}
+	std::string hwpName;
+	std::vector<sRegVOdy> pibmsRegSetOdy;
+	ReturnCode fapiRc;
 
-	ReturnCode fapiRc = p10_pibms_reg_dump(proc, pibmsRegSet);
+	if (PROC_SBE_DUMP == sbeTypeId) {
+		for (auto& reg : pibms_regs_2dump) {
+			sRegV regv;
+			regv.reg = reg;
+			pibmsRegSet.emplace_back(regv);
+		}
+		fapiRc = p10_pibms_reg_dump(target, pibmsRegSet);
+		hwpName = "p10_pibms_reg_dump";
+	} else if (ODYSSEY_SBE_DUMP == sbeTypeId) {
+		for (auto& reg : pibms_regs_2dump_ody) {
+			sRegVOdy regv;
+			regv.reg = reg;
+			pibmsRegSetOdy.emplace_back(regv);
+		}
+		fapiRc = ody_pibms_reg_dump(target, pibmsRegSetOdy);
+		hwpName = "ody_pibms_reg_dump";
+	}
 	if (fapiRc != FAPI2_RC_SUCCESS) {
-		log(level::ERROR,
-		    "Failed in p10_pibms_reg_dump for proc=%s, rc=0x%08X",
-		    pdbg_target_path(proc), fapiRc);
-		throw std::runtime_error("p10_pibms_reg_dump failed");
+		log(level::ERROR, "Failed in %s for proc=%s, rc=0x%08X",
+		    hwpName, pdbg_target_path(target), fapiRc);
+		throw std::runtime_error(hwpName + " failed");
 	}
 	std::vector<DumpPIBMSRegVal> dumpRegs;
-	for (auto& reg : pibmsRegSet) {
-		dumpRegs.emplace_back(reg.reg.addr, reg.reg.name, reg.reg.attr,
-				      reg.value);
+	// As both pibmsRegSetOdy and pibmsRegSet can not have data at the
+	// same time thus
+	if (!pibmsRegSet.empty()) {
+		for (auto& reg : pibmsRegSet) {
+			dumpRegs.emplace_back(reg.reg.addr, reg.reg.name,
+					      reg.reg.attr, reg.value);
+		}
+	} else if (!pibmsRegSetOdy.empty()) {
+		for (auto& regs : pibmsRegSetOdy) {
+			dumpRegs.emplace_back(regs.reg.addr, regs.reg.name,
+					      regs.reg.attr, regs.value);
+		}
 	}
-
-	std::string dumpFilename = baseFilename + "p10_pibms_reg_dump";
+	std::string dumpFilename = baseFilename + hwpName;
 	std::filesystem::path basePath = dumpPath / dumpFilename;
 
 	// Writing the PIBMS register values to a file
@@ -427,47 +570,63 @@ void writePIBMEMDataToFile(const std::vector<uint64_t>& dumpData,
 
 /**
  * @brief Collects and writes PIBMEM dump data for a given processor target.
- * @param[in] proc The processor target from which to collect the PIBMEM dump
+ * @param[in] target The processor target from which to collect the PIBMEM dump
  * data.
  * @param[in] dumpPath The filesystem path where the dump file will be written.
  * @param[in] baseFilename The base filename to use for the dump file. This name
  * will be used to form the complete file path along with the dumpPath.
+ * @param sbeTypeId[in] The chip type, i.e.; proc or OCMB
  *
  * @throw std::runtime_error Throws if there is an error in collecting the
  * PIBMEM dump data or writing to the file.
  */
-void collectPIBMEMDump(struct pdbg_target* proc,
+void collectPIBMEMDump(struct pdbg_target* target,
 		       const std::filesystem::path& dumpPath,
-		       const std::string& baseFilename)
+		       const std::string& baseFilename, const int sbeTypeId)
 {
 	// Define these constants and types as per your requirement
 	const uint32_t pibmemDumpStartByte = 0;	      // Starting byte for dump
 	const uint32_t pibmemDumpNumOfByte = 0x7D400; // Number of bytes to read
 	const user_options userOptions =
 	    INTERMEDIATE_TILL_INTERMEDIATE; // User options, define as per your
-					    // code
+	const usr_options userOptionsOdy = INTERMEDIATE_TO_INTERMEDIATE;
+	// code
 	const bool eccEnable = false; // ECC enabled/disabled
 
 	std::vector<array_data_t>
 	    pibmemContents; // Type array_data_t should be defined in your code
+	std::vector<pibmem_array_data_t> pibmemContentsOdy;
+	ReturnCode fapiRc;
+	std::string hwpName;
 
-	ReturnCode fapiRc =
-	    p10_pibmem_dump(proc, pibmemDumpStartByte, pibmemDumpNumOfByte,
-			    userOptions, pibmemContents, eccEnable);
+	if (PROC_SBE_DUMP == sbeTypeId) {
+		fapiRc = p10_pibmem_dump(target, pibmemDumpStartByte,
+					 pibmemDumpNumOfByte, userOptions,
+					 pibmemContents, eccEnable);
+		hwpName = "p10_pibmem_dump";
+	} else if (ODYSSEY_SBE_DUMP == sbeTypeId) {
+		fapiRc = ody_pibmem_dump(target, pibmemDumpStartByte,
+					 pibmemDumpNumOfByte, userOptionsOdy,
+					 eccEnable, pibmemContentsOdy);
+		hwpName = "ody_pibmem_dump";
+	}
 	if (fapiRc != FAPI2_RC_SUCCESS) {
-		log(level::ERROR,
-		    "Failed in p10_pibmem_dump for proc=%s, rc=0x%08X",
-		    pdbg_target_path(proc), fapiRc);
-		throw std::runtime_error("p10_pibmem_dump failed");
+		log(level::ERROR, "Failed in %s for proc=%s, rc=0x%08X",
+		    hwpName, pdbg_target_path(target), fapiRc);
+		throw std::runtime_error(hwpName + " failed");
 	}
 	std::vector<uint64_t> dumpData;
-	for (auto& data : pibmemContents) {
-		dumpData.push_back(data.read_data);
+	// As both pibmemContentsOdy and pibmemContents can not have data at
+	// the same time thus
+	if (!pibmemContents.empty()) {
+		for (auto& data : pibmemContents)
+			dumpData.push_back(data.read_data);
+	} else if (!pibmemContentsOdy.empty()) {
+		for (auto& data : pibmemContentsOdy)
+			dumpData.push_back(data.rd_data);
 	}
-
-	std::string dumpFilename = baseFilename + "p10_pibmem_dump";
+	std::string dumpFilename = baseFilename + hwpName;
 	std::filesystem::path basePath = dumpPath / dumpFilename;
-
 	// Writing the PIBMEM data to a file
 	writePIBMEMDataToFile(dumpData, basePath);
 }
@@ -504,47 +663,74 @@ void writePPEStateToFile(const std::vector<DumpPPERegValue>& ppeState,
 /**
  * @brief Collects and writes the state of the Programmable Processing Element
  * (PPE).
- * @param[in] proc The processor target from which to collect the PPE state.
+ * @param[in] target The processor or Odyssey target from which to collect the
+ * PPE state.
  * @param[in] dumpPath The filesystem path where the dump file will be written.
  * @param[in] baseFilename The base filename to use for the dump file. This name
  * will be used to form the complete file path along with the dumpPath.
+ * @param sbeTypeId[in] The chip type, i.e.; proc or OCMB
  *
  * @throw std::runtime_error Throws if there is an error in collecting the PPE
  * state or writing to the file.
  */
-void collectPPEState(struct pdbg_target* proc,
+void collectPPEState(struct pdbg_target* target,
 		     const std::filesystem::path& dumpPath,
-		     const std::string& baseFilename)
+		     const std::string& baseFilename, const int sbeTypeId)
 {
 	PPE_DUMP_MODE mode = SNAPSHOT; // Define as per your requirement
-	uint32_t instanceNum = 0;      // Instance number, set as needed
+	ODY_PPE_DUMP_MODE modeOdy = O_SNAPSHOT;
+	uint32_t instanceNum = 0; // Instance number, set as needed
 	PPE_TYPES type =
 	    PPE_TYPE_SBE; // Set the PPE type as per your requirement
 
 	std::vector<Reg32Value_t> ppeGprsValue, ppeSprsValue, ppeXirsValue;
+	std::vector<Reg32Val_t> ppeGprsValueOdy, ppeSprsValueOdy,
+	    ppeXirsValueOdy;
+	std::string hwpName;
+	ReturnCode fapiRc;
 
-	ReturnCode fapiRc =
-	    p10_ppe_state(proc, type, instanceNum, mode, ppeGprsValue,
-			  ppeSprsValue, ppeXirsValue);
+	if (sbeTypeId == PROC_SBE_DUMP) {
+		fapiRc =
+		    p10_ppe_state(target, type, instanceNum, mode, ppeGprsValue,
+				  ppeSprsValue, ppeXirsValue);
+		hwpName = "p10_ppe_state";
+	} else if (sbeTypeId == ODYSSEY_SBE_DUMP) {
+		fapiRc = ody_ppe_state(target, type, instanceNum, modeOdy,
+				       ppeGprsValueOdy, ppeSprsValueOdy,
+				       ppeXirsValueOdy);
+		hwpName = "ody_ppe_state";
+	}
+
 	if (fapiRc != FAPI2_RC_SUCCESS) {
-		log(level::ERROR,
-		    "Failed in p10_ppe_state for proc=%s, rc=0x%08X",
-		    pdbg_target_path(proc), fapiRc);
-		throw std::runtime_error("p10_ppe_state failed");
+		log(level::ERROR, "Failed in %s for proc=%s, rc=0x%08X",
+		    hwpName, pdbg_target_path(target), fapiRc);
+		throw std::runtime_error(hwpName + " failed");
 	}
 
 	std::vector<DumpPPERegValue> ppeState;
-	for (auto& spr : ppeSprsValue) {
-		ppeState.emplace_back(spr.number, spr.value);
-	}
-	for (auto& xir : ppeXirsValue) {
-		ppeState.emplace_back(xir.number, xir.value);
-	}
-	for (auto& gpr : ppeGprsValue) {
-		ppeState.emplace_back(gpr.number, gpr.value);
+	if (sbeTypeId == PROC_SBE_DUMP) {
+		for (auto& spr : ppeSprsValue) {
+			ppeState.emplace_back(spr.number, spr.value);
+		}
+		for (auto& xir : ppeXirsValue) {
+			ppeState.emplace_back(xir.number, xir.value);
+		}
+		for (auto& gpr : ppeGprsValue) {
+			ppeState.emplace_back(gpr.number, gpr.value);
+		}
+	} else if (sbeTypeId == ODYSSEY_SBE_DUMP) {
+		for (auto& spr : ppeSprsValueOdy) {
+			ppeState.emplace_back(spr.number, spr.value);
+		}
+		for (auto& xir : ppeXirsValueOdy) {
+			ppeState.emplace_back(xir.number, xir.value);
+		}
+		for (auto& gpr : ppeGprsValueOdy) {
+			ppeState.emplace_back(gpr.number, gpr.value);
+		}
 	}
 
-	std::string dumpFilename = baseFilename + "p10_ppe_state";
+	std::string dumpFilename = baseFilename + hwpName;
 	std::filesystem::path basePath = dumpPath / dumpFilename;
 
 	// Writing the PPE state data to a file
@@ -553,17 +739,26 @@ void collectPPEState(struct pdbg_target* proc,
 
 /**
  * @brief Finalizes the collection process.
- * @param[in] pib The PIB target for which the collection is being finalized.
+ * @param[in] pib_fsi The PIB (For PROC) or FSI (For Odyssey) target for which
+ * the collection is being finalized.
  * @param[in] dumpPath The filesystem path where the dump was written. Used for
  * cleanup in case of failure.
  * @param[in] isSuccess A boolean flag indicating whether the preceding
  * collection steps were successful.
+ * @param sbeTypeId The chip type ID
  */
-void finalizeCollection(struct pdbg_target* pib,
-			const std::filesystem::path& dumpPath, bool isSuccess)
+void finalizeCollection(struct pdbg_target* pib_fsi,
+			const std::filesystem::path& dumpPath, bool isSuccess,
+			const int sbeTypeId)
 {
 	// Attempt to set the SBE state to the final state (e.g., FAILED)
-	if (0 > sbe_set_state(pib, SBE_STATE_FAILED)) {
+	auto rv = -1;
+	if (PROC_SBE_DUMP == sbeTypeId)
+		rv = sbe_set_state(pib_fsi, SBE_STATE_FAILED);
+	else if (ODYSSEY_SBE_DUMP == sbeTypeId)
+		rv = sbe_ody_set_state(pib_fsi, SBE_STATE_FAILED);
+
+	if (0 > rv) {
 		log(level::ERROR, "Failed to set SBE state to FAILED");
 		// Handle error if needed
 	}
@@ -587,51 +782,76 @@ void finalizeCollection(struct pdbg_target* pib,
 void collectSBEDump(uint32_t id, uint32_t failingUnit,
 		    const std::filesystem::path& dumpPath, const int sbeTypeId)
 {
-	if (sbeTypeId != static_cast<uint16_t>(10)) {
-		throw dumpError_t(exception::HWP_EXECUTION_FAILED);
-	}
-
 	log(level::INFO,
 	    "Collecting SBE dump: path=%s, id=%d, chip position=%d",
 	    dumpPath.string().c_str(), id, failingUnit);
 
 	std::stringstream ss;
 	ss << std::setw(8) << std::setfill('0') << id;
-	std::string baseFilename =
-	    ss.str() + ".0_" + std::to_string(failingUnit) + "_SbeData_p10_";
 
-	struct pdbg_target* proc = nullptr;
+	std::string sbeChipType;
+	if (PROC_SBE_DUMP == sbeTypeId)
+		sbeChipType = "_p10_";
+	else if (ODYSSEY_SBE_DUMP == sbeTypeId)
+		sbeChipType = "_ody_";
+
+	std::string baseFilename = ss.str() + ".0_" +
+				   std::to_string(failingUnit) + "_SbeData" +
+				   sbeChipType;
+
+	struct pdbg_target* proc_ody = nullptr;
 	struct pdbg_target* pib = nullptr;
+	struct pdbg_target* fsi = nullptr;
 
 	try {
 		// Execute pre-collection steps and get the proc target
 		initializePdbgLibEkb();
 
-		proc = getProcFromFailingId(failingUnit);
-		probeTarget(proc, "fsi");
-		pib = probeTarget(proc, "pib");
+		proc_ody = getTargetFromFailingId(failingUnit, sbeTypeId);
+		pib = probeTarget(proc_ody, "pib", sbeTypeId);
+		fsi = probeTarget(proc_ody, "fsi", sbeTypeId);
 
-		checkSbeState(pib);
-		executeSbeExtractRc(proc, dumpPath);
+		if (PROC_SBE_DUMP == sbeTypeId)
+			checkSbeState(pib, sbeTypeId);
+		else if (ODYSSEY_SBE_DUMP == sbeTypeId)
+			checkSbeState(fsi, sbeTypeId);
+
+		executeSbeExtractRc(proc_ody, dumpPath, sbeTypeId);
 
 		// Collect various dumps
-		collectLocalRegDump(proc, dumpPath, baseFilename);
-		collectPIBMSRegDump(proc, dumpPath, baseFilename);
-		collectPIBMEMDump(proc, dumpPath, baseFilename);
-		collectPPEState(proc, dumpPath, baseFilename);
+		collectLocalRegDump(proc_ody, dumpPath, baseFilename,
+				    sbeTypeId);
+		collectPIBMSRegDump(proc_ody, dumpPath, baseFilename,
+				    sbeTypeId);
+		collectPIBMEMDump(proc_ody, dumpPath, baseFilename, sbeTypeId);
+		collectPPEState(proc_ody, dumpPath, baseFilename, sbeTypeId);
 
 		// Finalize the collection process
-		finalizeCollection(pib, dumpPath,
-				   true); // Indicate successful completion
+		if (PROC_SBE_DUMP == sbeTypeId)
+			finalizeCollection(
+			    pib, dumpPath, true,
+			    sbeTypeId); // Indicate successful completion
+		else if (ODYSSEY_SBE_DUMP == sbeTypeId)
+			finalizeCollection(
+			    fsi, dumpPath, true,
+			    sbeTypeId); // Indicate successful completion
+
 		log(level::INFO, "SBE dump collection completed successfully");
 	} catch (const std::exception& e) {
 		log(level::ERROR, "Failed to collect the SBE dump: %s",
 		    e.what());
 		// In case of any exception, attempt to finalize with a failure
 		// state
-		if (proc) {
-			pib = getPibTarget(proc);
-			finalizeCollection(pib, dumpPath, false);
+		if (proc_ody) {
+			if (PROC_SBE_DUMP == sbeTypeId) {
+				pib = probeTarget(proc_ody, "pib", sbeTypeId);
+				finalizeCollection(pib, dumpPath, false,
+						   sbeTypeId);
+			} else if (ODYSSEY_SBE_DUMP == sbeTypeId) {
+				fsi = probeTarget(proc_ody, "fsi", sbeTypeId);
+				finalizeCollection(fsi, dumpPath, false,
+						   sbeTypeId);
+			}
 		}
 		throw;
 	}


### PR DESCRIPTION
We have now OdySsey chip along with the existing p10 which supports SBE dump collection. In future we may have more varieties of chips. So the new code to support Odyssey operation has been added.

Test:

busctl --verbose call org.open_power.Dump.Manager /org/openpower/dump xyz.openbmc_project.Dump.Create CreateDump a{sv} 3 "com.ibm.Dump.Create.CreateParameters.DumpType" s "com.ibm.Dump.Create.DumpType.MemoryBufferSBE" "com.ibm.Dump.Create.CreateParameters.ErrorLogId" t 0xDEADBEEF "com.ibm.Dump.Create.CreateParameters.FailingUnitId" t 2

MESSAGE "o" {
OBJECT_PATH "/xyz/openbmc_project/dump/msbe/entry/40000003";
};

Jan 29 08:53:46 phosphor-dump-manager[498]: Create dump type(sbedump) with id(40000003)                                                                                                                        
Jan 29 08:53:46 phosphor-dump-manager[12970]: Creating dump with dumpPath(/var/lib/phosphor-debug-collector/msbedump/40000003) id(40000003) available space(102400) eid(deadbeef) dump type(11) failing unit(2)
Jan 29 08:53:46 phosphor-dump-manager[12982]: Collecting SBE dump: path=/tmp/dump_40000003_1706518426/plat_dump, id=40000003, chip position=2                                                                  
Jan 29 08:53:46 phosphor-dump-manager[12982]: PDBG Initilization started                                                                                                                                       
Jan 29 08:53:46 phosphor-dump-manager[12982]: Entering getTargetFromFailingId                                                                                                                                  
Jan 29 08:53:46 phosphor-dump-manager[12982]: Exiting getTargetFromFailingId                                                                                                                                   
Jan 29 08:53:46 phosphor-dump-manager[12982]: Entering probeTarget                                                                                                                                              
Jan 29 08:53:46 phosphor-dump-manager[12982]: Probing target = /proc0/ocmb2                                                                                                                                    
Jan 29 08:53:46 phosphor-dump-manager[12982]: Exiting probeTarget                                                                                                                                              
Jan 29 08:53:46 phosphor-dump-manager[12982]: Entering probeTarget                                                                                                                                             
Jan 29 08:53:46 phosphor-dump-manager[12982]: Probing target = /hmfsi-ody@110                                                                                                                                  
Jan 29 08:53:46 phosphor-dump-manager[12982]: Exiting probeTarget                                                                                                                                              
Jan 29 08:53:46 phosphor-dump-manager[12982]: Entering checkSbeState                                                                                                                                           
Jan 29 08:53:46 phosphor-dump-manager[12982]: Exiting checkSbeState                                                                                                        
Jan 29 08:53:46 phosphor-dump-manager[12982]: Entering executeSbeExtractRc                                                                                                 
Jan 29 08:53:46 phosphor-dump-manager[12982]: err: ody_extract_sbe_rc:269 The external halt_req input was active.                                                          
Jan 29 08:53:46 phosphor-dump-manager[12982]: err: ody_extract_sbe_rc:467 Instruction machine check at Address = FFF80014                                                  
Jan 29 08:53:46 phosphor-dump-manager[12982]: extract_sbe_rc for target=/proc0/pib/perv12/mc0/mi0/mcc1/omi0/ocmb0 returned rc=0x7ED76F54 and SBE Recovery Action=0x00000000
Jan 29 08:53:46 phosphor-dump-manager[12982]: Exiting executeSbeExtractRc                                                                                                  
Jan 29 08:53:46 phosphor-dump-manager[12982]: Entering collectLocalRegDump                                                                                                 
Jan 29 08:53:46 phosphor-dump-manager[12982]: Entering writeSBERegValuesToFile                                                                                             
Jan 29 08:53:46 phosphor-dump-manager[12982]: Exiting writeSBERegValuesToFile                                                                                              
Jan 29 08:53:46 phosphor-dump-manager[12982]: Exiting collectLocalRegDump                                                                                                  
Jan 29 08:53:46 phosphor-dump-manager[12982]: Entering collectPIBMSRegDump                                                                                                 
Jan 29 08:53:46 phosphor-dump-manager[12982]: Entering writePIBMSRegValuesToFile                                                                                           
Jan 29 08:53:46 phosphor-dump-manager[12982]: Exiting writePIBMSRegValuesToFile                                                                                            
Jan 29 08:53:46 phosphor-dump-manager[12982]: Exiting collectPIBMSRegDump                                                                                                  
Jan 29 08:53:46 phosphor-dump-manager[12982]: Entering collectPIBMEMDump                                                                                                   
Jan 29 08:53:50 pldmd[890]: The eid:InstanceID 10:1 is using.                                                                                                                                                                     
Jan 29 08:53:50 pldmd[890]: Failed to receive response for get_state_sensor_readings command, sensor id : 21861                                          
Jan 29 08:56:26 phosphor-dump-manager[12982]: Entering writePIBMEMDataToFile                                                                             
Jan 29 08:56:26 phosphor-dump-manager[12982]: Exiting writePIBMEMDataToFile                                                                              
Jan 29 08:56:26 phosphor-dump-manager[12982]: Exiting collectPIBMEMDump                                                                                  
Jan 29 08:56:26 phosphor-dump-manager[12982]: Entering collectPPEState                                                                                   
Jan 29 08:56:26 phosphor-dump-manager[12982]: ppe_get_xir_addr(i_ppe_type, PPE_IDX_XIXCR, i_ppe_instance_num) returned as d0000                          
Jan 29 08:56:26 phosphor-dump-manager[12982]: ppe_get_xir_addr(i_ppe_type, PPE_IDX_XIRAMDBG, i_ppe_instance_num) returned as d0003                       
Jan 29 08:56:26 phosphor-dump-manager[12982]: ppe_get_xir_addr(i_ppe_type, PPE_IDX_XIRAMEDR, i_ppe_instance_num) returned as d0004                       
Jan 29 08:56:26 phosphor-dump-manager[12982]: ppe_get_xir_addr(i_ppe_type, PPE_IDX_XIDBGPRO, i_ppe_instance_num) returned as d0005                       
Jan 29 08:56:26 phosphor-dump-manager[12982]: ppe_get_xir_addr(i_ppe_type, PPE_IDX_XIDBGINF, i_ppe_instance_num) returned as d000f                       
Jan 29 08:56:27 phosphor-dump-manager[12982]: Entering writePPEStateToFile                                                                                                                                                        
Jan 29 08:56:27 phosphor-dump-manager[12982]: Exiting writePPEStateToFile                                                                                                                                                         
Jan 29 08:56:27 phosphor-dump-manager[12982]: Exiting collectPPEState                                                                                                                                                             
Jan 29 08:56:27 phosphor-dump-manager[12982]: Entering finalizeCollection                                                                                                                                                         
Jan 29 08:56:27 phosphor-dump-manager[12982]: Collection process completed                                                                                                                                                        
Jan 29 08:56:27 phosphor-dump-manager[12982]: Exiting finalizeCollection                                                                                                                                                          
Jan 29 08:56:27 phosphor-dump-manager[12982]: SBE dump collection completed successfully                                                                 
Jan 29 08:56:27 phosphor-dump-manager[13025]: plat_dump/40000003.0_2_SbeData_ody_ody_pibmem_dump                                                         
Jan 29 08:56:27 phosphor-dump-manager[13025]: plat_dump/40000003.0_2_SbeData_ody_ody_pibms_reg_dump                                                      
Jan 29 08:56:27 phosphor-dump-manager[13025]: plat_dump/40000003.0_2_SbeData_ody_ody_ppe_state                                                           
Jan 29 08:56:27 phosphor-dump-manager[13025]: plat_dump/40000003.0_2_SbeData_ody_ody_sbe_localreg_dump                                                   
Jan 29 08:56:27 phosphor-dump-manager[13025]: info.yaml                                                                                                  
Jan 29 08:56:27 phosphor-dump-manager[12970]: Adding Dump Header :/usr/share/dreport.d/include.d/gendumpheader                                           
Jan 29 08:56:28 bmcweb[908]: (2024-01-29 08:56:28) [ERROR "event_dbus_monitor.hpp":468] Invalid dump type received when listening for dump created signal
Jan 29 08:56:28 phosphor-dump-manager[12970]: Mon Jan 29 08:56:28 UTC 2024 Successfully completed                                                        
Jan 29 08:56:28 phosphor-dump-manager[498]: OriginatorId is not provided                                                                                 
Jan 29 08:56:28 phosphor-dump-manager[498]: OriginatorType is not provided. Replacing the string with the default value                                  
Jan 29 08:56:28 pvm_dump_offload[11928]: Watch interfaceAdded path (/xyz/openbmc_project/dump/bmc/entry/15)                                              
Jan 29 08:56:28 phosphor-dump-manager[498]: Dump packaging completed                                                                                                                                           
Jan 29 08:56:28 phosphor-dump-manager[12970]: BMC dump initiated o "/xyz/openbmc_project/dump/bmc/entry/15"    

Signed-off-by: Swarnendu Roy Chowdhury <swarnendu.roy.chowdhury@ibm.com>