### PR TITLE
Remove runtime exception after dump collection failure

### DIFF
--- a/libphal/libphal.H
+++ b/libphal/libphal.H
@@ -152,15 +152,6 @@ void getDump(struct pdbg_target *chip, const uint8_t type, const uint8_t clock,
 void threadStopProc(struct pdbg_target *proc);
 
 
-/**
- * @brief Check whether the input target is an Odyssey OCMB
- * 
- * @param target Pointer to the chip tartget
- * 
- * @return True if Odyssey OCMB chip else false
-*/
-bool is_ody_ocmb_chip(struct pdbg_target *target);
-
 } // namespace sbe
 
 namespace pdbg

--- a/libphal/phal_dump.C
+++ b/libphal/phal_dump.C
@@ -400,8 +400,6 @@ void writeSBERegValuesToFile(const std::vector<DumpSBERegVal>& dumpRegs,
  * will be used to form the complete file path along with the dumpPath.
  * @param sbeTypeId[in] Chip type ID
  *
- * @throw std::runtime_error Throws if there is an error in collecting the local
- * register dump or writing to the file.
  */
 void collectLocalRegDump(struct pdbg_target* target,
 			 const std::filesystem::path& dumpPath,
@@ -424,7 +422,7 @@ void collectLocalRegDump(struct pdbg_target* target,
 	if (fapiRc != FAPI2_RC_SUCCESS) {
 		log(level::ERROR, "Failed in %s for proc=%s, rc=0x%08X", target,
 		    pdbg_target_path(target), fapiRc);
-		throw std::runtime_error(hwpName + " failed");
+		return;
 	}
 	std::vector<DumpSBERegVal> dumpRegs;
 	// As both sbeScomRegValueOdy and sbeScomRegValue can not have data
@@ -484,8 +482,6 @@ void writePIBMSRegValuesToFile(const std::vector<DumpPIBMSRegVal>& dumpRegs,
  * @param sbeTypeId[in] Chip type ID
  * will be used to form the complete file path along with the dumpPath.
  *
- * @throw std::runtime_error Throws if there is an error in collecting the PIBMS
- * register dump or writing to the file.
  */
 void collectPIBMSRegDump(struct pdbg_target* target,
 			 const std::filesystem::path& dumpPath,
@@ -516,7 +512,7 @@ void collectPIBMSRegDump(struct pdbg_target* target,
 	if (fapiRc != FAPI2_RC_SUCCESS) {
 		log(level::ERROR, "Failed in %s for proc=%s, rc=0x%08X",
 		    hwpName, pdbg_target_path(target), fapiRc);
-		throw std::runtime_error(hwpName + " failed");
+		return;
 	}
 	std::vector<DumpPIBMSRegVal> dumpRegs;
 	// As both pibmsRegSetOdy and pibmsRegSet can not have data at the
@@ -577,8 +573,6 @@ void writePIBMEMDataToFile(const std::vector<uint64_t>& dumpData,
  * will be used to form the complete file path along with the dumpPath.
  * @param sbeTypeId[in] The chip type, i.e.; proc or OCMB
  *
- * @throw std::runtime_error Throws if there is an error in collecting the
- * PIBMEM dump data or writing to the file.
  */
 void collectPIBMEMDump(struct pdbg_target* target,
 		       const std::filesystem::path& dumpPath,
@@ -613,7 +607,7 @@ void collectPIBMEMDump(struct pdbg_target* target,
 	if (fapiRc != FAPI2_RC_SUCCESS) {
 		log(level::ERROR, "Failed in %s for proc=%s, rc=0x%08X",
 		    hwpName, pdbg_target_path(target), fapiRc);
-		throw std::runtime_error(hwpName + " failed");
+		return;
 	}
 	std::vector<uint64_t> dumpData;
 	// As both pibmemContentsOdy and pibmemContents can not have data at
@@ -670,8 +664,6 @@ void writePPEStateToFile(const std::vector<DumpPPERegValue>& ppeState,
  * will be used to form the complete file path along with the dumpPath.
  * @param sbeTypeId[in] The chip type, i.e.; proc or OCMB
  *
- * @throw std::runtime_error Throws if there is an error in collecting the PPE
- * state or writing to the file.
  */
 void collectPPEState(struct pdbg_target* target,
 		     const std::filesystem::path& dumpPath,
@@ -704,7 +696,7 @@ void collectPPEState(struct pdbg_target* target,
 	if (fapiRc != FAPI2_RC_SUCCESS) {
 		log(level::ERROR, "Failed in %s for proc=%s, rc=0x%08X",
 		    hwpName, pdbg_target_path(target), fapiRc);
-		throw std::runtime_error(hwpName + " failed");
+		return;
 	}
 
 	std::vector<DumpPPERegValue> ppeState;

--- a/libphal/phal_dump.C
+++ b/libphal/phal_dump.C
@@ -158,7 +158,7 @@ struct pdbg_target* getTargetFromFailingId(const uint32_t failingUnit,
 			continue;
 		}
 		if (sbeTypeId == ODYSSEY_SBE_DUMP) {
-			if (!openpower::phal::sbe::is_ody_ocmb_chip(target)) {
+			if (!isOdysseyChip(target)) {
 				log(level::ERROR,
 				    "No ocmb target found to execute the dump "
 				    "for failing unit=%d",

--- a/libphal/phal_pdbg.C
+++ b/libphal/phal_pdbg.C
@@ -63,24 +63,6 @@ bool isTgtFunctional(struct pdbg_target *target)
 
 	return hwasState.functional;
 }
-/*
-bool is_ody_ocmb_chip(struct pdbg_target *target)
-{
-	const uint16_t ODYSSEY_CHIP_ID = 0x60C0;
-        const uint8_t ATTR_TYPE_OCMB_CHIP = 75;
-	ATTR_CHIP_ID_type ODYSSEY_CHIP_ID = 
-	ATTR_TYPE_type type;
-	DT_GET_PROP(ATTR_TYPE, target, type);
-        if(type != ATTR_TYPE_OCMB_CHIP) {
-                                return false;
-        }
-        ATTR_CHIP_ID_type chipId = 0;
-        pdbg_target_get_attribute(ATTR_CHIP_ID, target,chipId);
-        if(chipId == ODYSSEY_CHIP_ID) {
-                return true;
-        }
-        return false;
-}*/
 
 bool isPrimaryProc(struct pdbg_target *proc)
 {

--- a/libphal/phal_sbe.C
+++ b/libphal/phal_sbe.C
@@ -20,23 +20,6 @@ using namespace openpower::phal;
 using namespace openpower::phal::utils::pdbg;
 using namespace openpower::phal::pdbg;
 
-bool is_ody_ocmb_chip(struct pdbg_target *target)
-{
-	const uint16_t ODYSSEY_CHIP_ID = 0x60C0;
-    const uint8_t ATTR_TYPE_OCMB_CHIP = 75;
-    ATTR_TYPE_Type type;
-    DT_GET_PROP(ATTR_TYPE, target, type);
-    if(type != ATTR_TYPE_OCMB_CHIP) {
-    	return false;
-    }
-    ATTR_CHIP_ID_Type chipId = 0;
-    DT_GET_PROP(ATTR_CHIP_ID, target,chipId);
-    if(chipId == ODYSSEY_CHIP_ID) {
-        return true;
-	}    
-    return false;
-}
-
 /**
  * @brief helper function to log SBE debug data
  *
@@ -173,6 +156,7 @@ void validateSBEState(struct pdbg_target *proc)
 		throw sbeError_t(exception::SBE_CHIPOP_NOT_ALLOWED);
 	}
 }
+
 void setState(struct pdbg_target *proc, enum sbe_state state)
 {
 	// get PIB target
@@ -343,7 +327,7 @@ void getDump(struct pdbg_target *chip, const uint8_t type, const uint8_t clock,
 	log(level::INFO, "Enter: getDump(%d) on %s", type,
 	    pdbg_target_path(chip));
 
-	if (is_ody_ocmb_chip(chip))
+	if (isOdysseyChip(chip))
 	{
 		auto ret = sbe_dump(chip, type, clock, faCollect, data, dataLen);
 		if (ret != 0)

--- a/libphal/utils_pdbg.C
+++ b/libphal/utils_pdbg.C
@@ -128,6 +128,23 @@ struct pdbg_target *getTgtFromBinPath(const ATTR_PHYS_BIN_PATH_Type &binPath)
 	return targetInfo.target;
 }
 
+bool isOdysseyChip(struct pdbg_target *target)
+{
+    const uint16_t ODYSSEY_CHIP_ID = 0x60C0;
+    const uint8_t ATTR_TYPE_OCMB_CHIP = 75;
+    ATTR_TYPE_Type type;
+    DT_GET_PROP(ATTR_TYPE, target, type);
+    if(type != ATTR_TYPE_OCMB_CHIP) {
+        return false;
+    }
+    ATTR_CHIP_ID_Type chipId = 0;
+    DT_GET_PROP(ATTR_CHIP_ID, target,chipId);
+    if(chipId == ODYSSEY_CHIP_ID) {
+        return true;
+        }
+    return false;
+}
+
 void validateProcTgt(struct pdbg_target *tgt)
 {
 	const char *tgtClass = pdbg_target_class_name(tgt);
@@ -142,6 +159,15 @@ void validateProcTgt(struct pdbg_target *tgt)
 		    "validateProcTgt: Target is not processor type");
 		throw pdbgError_t(exception::PDBG_TARGET_INVALID);
 	}
+}
+
+void validateChipTgt(struct pdbg_target *tgt)
+{
+	if (isOdysseyChip(tgt))
+	{
+		return;
+	}
+	validateProcTgt(tgt);
 }
 
 } // namespace pdbg

--- a/libphal/utils_pdbg.H
+++ b/libphal/utils_pdbg.H
@@ -51,5 +51,14 @@ struct pdbg_target *getTgtFromBinPath(const ATTR_PHYS_BIN_PATH_Type &binPath);
  */
 void validateProcTgt(struct pdbg_target *tgt);
 
+/**
+ * @brief Check whether the input target is an Odyssey OCMB
+ *
+ * @param target Pointer to the chip tartget
+ *
+ * @return True if Odyssey OCMB chip else false
+*/
+bool isOdysseyChip(struct pdbg_target *target);
+
 } // namespace pdbg
 } // namespace openpower::phal::utils


### PR DESCRIPTION
There are exceptions thrown after HWP failure in the case of SBE dump and which is not needd as the dump collection should continue to next HWP and attempt to collect as much as data possible.