### PR TITLE
POZ: capture pel severity from FFDC packet

### DIFF
--- a/libphal/libphal.H
+++ b/libphal/libphal.H
@@ -78,6 +78,7 @@ bool isDumpAllowed(struct pdbg_target *proc);
  *        pdbg function sbe_ffdc_get().
  *
  * @param[in] target ocmb target to operate on
+ * @param[in] coSuccess flag to inidicate if the chipop is sucess 
  *
  * return  sbeError_t sbe error exception type object which
  *         includes chip-op failure reason code and, file which includes
@@ -86,7 +87,7 @@ bool isDumpAllowed(struct pdbg_target *proc);
  * Exceptions: SbeError for pdbg lib function failure
  *             std::runtime_error - for file operation failure.
  */
-sbeError_t capturePOZFFDC(struct pdbg_target *target);
+sbeError_t capturePOZFFDC(struct pdbg_target *target, bool coSuccess);
 
 
 /**
@@ -94,6 +95,7 @@ sbeError_t capturePOZFFDC(struct pdbg_target *target);
  *        pdbg function sbe_ffdc_get().
  *
  * @param[in] proc processor target to operate on
+ * @param[in] coSuccess flag to inidicate if the chipop is sucess 
  *
  * return  sbeError_t sbe error exception type object which
  *         includes chip-op failure reason code and, file which includes
@@ -102,7 +104,7 @@ sbeError_t capturePOZFFDC(struct pdbg_target *target);
  * Exceptions: SbeError for pdbg lib function failure
  *             std::runtime_error - for file operation failure.
  */
-sbeError_t captureFFDC(struct pdbg_target *proc);
+sbeError_t captureFFDC(struct pdbg_target *proc, bool coSuccess = false);
 
 /**
  * @brief Execute continue mpipl on the pib

--- a/libphal/phal_exception.C
+++ b/libphal/phal_exception.C
@@ -5,18 +5,34 @@ namespace openpower::phal
 {
 namespace exception
 {
+//taken from error_info_defs.H, including the header file breaks logging and
+//debug collector as they need to include ekb in include path
+enum errlSeverity_t
+{
+	FAPI2_ERRL_SEV_UNDEFINED     = 0x00, /// Used internally by ffdc mechanism
+	FAPI2_ERRL_SEV_RECOVERED     = 0x10, /// Not seen by customer
+	FAPI2_ERRL_SEV_PREDICTIVE    = 0x20, /// Error recovered but customer will see
+	FAPI2_ERRL_SEV_UNRECOVERABLE = 0x40  /// Unrecoverable, general
+};
 
 using namespace openpower::phal::logging;
 
+SbeError::SbeError(ERR_TYPE type, int fd, const fs::path fileName) : type(type)
+{
+	ffdcFileList.insert(
+		std::make_pair(DEFAULT_SLID,
+			std::make_tuple(FAPI2_ERRL_SEV_UNRECOVERABLE, fd, fileName)));
+}
 SbeError::~SbeError()
 {
 	for(const auto& iter : ffdcFileList)
 	{
-		if(fs::remove(iter.second.second) == false)
+		auto tuple = iter.second;
+		if(fs::remove(std::get<2>(tuple)) == false)
 		{
 			// Log error message and exit from destructor
 			log(level::ERROR, "File(%s) remove failed(errnno:%d)",
-			    iter.second.second.c_str(), errno);
+			    std::get<2>(tuple), errno);
 		}
 	}
 }

--- a/libphal/phal_exception.H
+++ b/libphal/phal_exception.H
@@ -47,6 +47,7 @@ enum ERR_TYPE {
 	PDBG_FSI_READ_FAIL,
 	PDBG_FSI_WRITE_FAIL,
 	SBE_DUMP_IS_ALREADY_COLLECTED,
+	SBE_INTERNAL_FFDC_DATA,
 };
 constexpr uint16_t DEFAULT_SLID = 0;
 // Error type to message map.

--- a/libphal/phal_exception.H
+++ b/libphal/phal_exception.H
@@ -2,14 +2,25 @@
 
 #include <exception>
 #include <map>
+#include <unordered_map>
 #include <string>
 #include <filesystem>
 
 namespace openpower::phal
 {
-namespace fs = std::filesystem;
+//taken from error_info_defs.H, including the header file breaks logging and
+//debug collector as they need to include ekb in include path
+enum errlSeverity_t
+{
+    FAPI2_ERRL_SEV_UNDEFINED     = 0x00, /// Used internally by ffdc mechanism
+    FAPI2_ERRL_SEV_RECOVERED     = 0x10, /// Not seen by customer
+    FAPI2_ERRL_SEV_PREDICTIVE    = 0x20, /// Error recovered but customer will see
+    FAPI2_ERRL_SEV_UNRECOVERABLE = 0x40  /// Unrecoverable, general
+};
 
-using FFDCFileList = std::map<uint16_t, std::pair<int, fs::path>>;
+namespace fs = std::filesystem;
+//slid, severity, fd, filename
+using FFDCFileList = std::unordered_map<uint16_t, std::tuple<uint8_t, int, fs::path>>;
 namespace exception
 {
 
@@ -79,13 +90,7 @@ struct phalError : public std::exception {
 class SbeError final : public phalError
 {
        public:
-	SbeError(ERR_TYPE type, int fd, const fs::path fileName) : type(type)
-	{
-		// ffdcFileList.insert(DEFAULT_SLID, std::make_pair(fd,
-		// fileName));
-		ffdcFileList.insert(
-		    std::make_pair(DEFAULT_SLID, std::make_pair(fd, fileName)));
-	}
+	SbeError(ERR_TYPE type, int fd, const fs::path fileName);
 	SbeError(ERR_TYPE type) : type(type){};
 	SbeError() : type(NONE){};
 	SbeError(ERR_TYPE type, const FFDCFileList &fileList) :
@@ -119,28 +124,31 @@ class SbeError final : public phalError
 	int getFd() const noexcept
 	{
 		if (!ffdcFileList.empty()) {
-			const auto &it = ffdcFileList.begin();
-			return it->second.first;
+			const auto& tuple = ffdcFileList.begin()->second;
+			return std::get<1>(tuple);
 		}
 		return -1;
 	}
 
 	/* return filename information */
-	const std::string getFileName() const noexcept
+	std::string getFileName() const noexcept
 	{
 		if (!ffdcFileList.empty()) {
-			const auto &it = ffdcFileList.begin();
-			return it->second.second;
+    		const auto& tuple = ffdcFileList.begin()->second;
+			return std::get<2>(tuple);
 		}
 		return "";
 	}
 
 	/* return ffdcmap information */
-	const FFDCFileList getFfdcFileList() const noexcept
+	const FFDCFileList& getFfdcFileList() const noexcept
 	{
 		return ffdcFileList;
 	}
-
+	size_t getFfdcFileListSize() const noexcept
+	{
+		return ffdcFileList.size();
+	}
        private:
 	/* Error type */
 	ERR_TYPE type;

--- a/libphal/phal_sbe.C
+++ b/libphal/phal_sbe.C
@@ -310,57 +310,39 @@ sbeError_t capturePOZFFDC(struct pdbg_target *target)
 		return sbeError_t(exception::SBE_FFDC_NO_DATA);
 	}
 
-	//map - slid, <severty, data>
-	std::unordered_multimap<uint8_t, std::pair<uint8_t, std::vector<uint8_t>>> mulSlidData;
 	uint32_t offset = 0;
-	while ((offset < ffdcLen) &&
-		ffdcLen >= (offset + minFFDCPackageWordSizePOZ)) {
-		pozFfdcHeader *ffdc =
-			reinterpret_cast<pozFfdcHeader *>(bufPtr.getData() + offset);
+	//map - slid, <severty, data>
+	std::unordered_map<uint16_t, std::pair<uint8_t, std::vector<uint8_t>>> slidData;
+	while ((offset < ffdcLen) && (ffdcLen >= (offset + minFFDCPackageWordSizePOZ))) {
+		pozFfdcHeader* ffdc = reinterpret_cast<pozFfdcHeader*>(bufPtr.getData() + offset);
 		uint16_t magicBytes = ntohs(ffdc->magicByte);
 		assert(magicBytes == pozFfdcMagicCode);
-		uint32_t lenInBytes =
-			ntohs(ffdc->lengthinWords) * sizeof(uint32_t);
+
+		uint32_t lenInBytes = ntohs(ffdc->lengthinWords) * sizeof(uint32_t);
 		uint16_t slid = ntohs(ffdc->slid);
-		std::vector<uint8_t> data;
-		data.reserve(lenInBytes);
-		std::copy(bufPtr.getData() + offset,
-			  bufPtr.getData() + offset + lenInBytes,
-			  std::back_inserter(data));
 		uint8_t severity = ffdc->severity;
-		mulSlidData.emplace(slid, std::make_pair(severity, data));
-		offset += lenInBytes;
-	}
-	// now combine data with same slid numbers
-	std::unordered_map<uint8_t, std::pair<uint8_t, std::vector<uint8_t>>> slidData;
-	int prevKey = -1;
-	for (auto it = mulSlidData.begin(); it != mulSlidData.end(); ++it) {
-		if (it->first != prevKey) {
-			// New key found, write values associated with the key
-			auto range = mulSlidData.equal_range(it->first);
-			size_t totalSize = 0;
-			uint8_t severity = 0;
-			// from all the slids get the highest severity, assumption
-			// here is that the severity in error_info_defs.H under 
+
+		auto it = slidData.find(slid);
+		if (it == slidData.end()) {
+			// New slid found, insert into slidData
+			std::vector<uint8_t> data(lenInBytes);
+			std::copy(bufPtr.getData() + offset,
+				bufPtr.getData() + offset + lenInBytes, data.begin());
+			slidData.emplace(slid, std::make_pair(severity, std::move(data)));
+		} else {
+			// Slid already exists, update severity and append data
+			// assumption here is that the severity in error_info_defs.H under
 			// errlSeverity_t is defined from lower severity to higher
-			for (auto dataIt = range.first; dataIt != range.second;
-				++dataIt) {
-				auto& pair = dataIt->second;
-				totalSize += pair.second.size();
-				if(pair.first > severity) {
-					severity = pair.first;
-				}
+			if (severity > it->second.first) {
+				it->second.first = severity; // Update severity if higher
 			}
-			std::vector<uint8_t> data;
-			data.reserve(totalSize);
-			for (auto dataIt = range.first; dataIt != range.second;
-				++dataIt) {
-				auto& pair = dataIt->second;
-				data.insert(data.end(), pair.second.begin(),
-					pair.second.end());
-			}
-			slidData.emplace(it->first, std::make_pair(severity, data));
+			auto& existingData = it->second.second;
+			size_t prevSize = existingData.size();
+			existingData.resize(prevSize + lenInBytes);
+			std::copy(bufPtr.getData() + offset,
+				bufPtr.getData() + offset + lenInBytes, existingData.begin() + prevSize);
 		}
+		offset += lenInBytes;
 	}
 	FFDCFileList ffdcFileList;
 	for (auto &iter : slidData) {


### PR DESCRIPTION
1) Loop through all the FFDC packets
2) Capture packets matching the slid number
3) For a particular slid check all the packets for severity 4) Pick the highest severity from all the severity

Tested:
slid 1 has severity 40 and slide 3 has 4 packets
ensured pel1 is created with severity 40
ensured pel2 is created with highest severity 20

chip-op success received pending FFDC from SBE
IPL POZ capturePOZFFDC slid=1
IPL POZ capturePOZFFDC severity=40
IPL POZ capturePOZFFDC slid=3
IPL POZ capturePOZFFDC severity=10
IPL POZ capturePOZFFDC slid=3
IPL POZ capturePOZFFDC severity=20
IPL POZ capturePOZFFDC slid=3
IPL POZ capturePOZFFDC severity=20
IPL POZ capturePOZFFDC slid=3
IPL POZ capturePOZFFDC severity=20
IPL POZ capturePOZFFDC split severity =0x40
IPL POZ capturePOZFFDC split severity =0x20
OCMB fapi position is 2

root@rain71bmc:/tmp# peltool -l
{
    "0x50005C32": {
        "SRC":                  "BD20F401",
        "Message":              "chipop request failure reported by OCMB SBE",
        "PLID":                 "0x50005C32",
        "CreatorID":            "BMC",
        "Subsystem":            "Memory",
        "Commit Time":          "03/22/2024 15:11:15",
        "Sev":                  "Unrecoverable Error",
        "CompID":               "bmc ocmb errors"
    },
    "0x50005C33": {
        "SRC":                  "BD20F401",
        "Message":              "chipop request failure reported by OCMB SBE",
        "PLID":                 "0x50005C33",
        "CreatorID":            "BMC",
        "Subsystem":            "Memory",
        "Commit Time":          "03/22/2024 15:11:15",
        "Sev":                  "Predictive Error",
        "CompID":               "bmc ocmb errors"
    }
}

Change-Id: I21a09a82b807aeb94bdfdf8441cb365235ed29d4