### PR TITLE
libphal: Changing FAPI unit pos to PDBG traget index

### DIFF
--- a/libphal/phal_dump.C
+++ b/libphal/phal_dump.C
@@ -148,12 +148,7 @@ struct pdbg_target* getTargetFromFailingId(const uint32_t failingUnit,
 
 	pdbg_for_each_class_target(chipTypeString.c_str(), target)
 	{
-		uint8_t targetIdx = 0;
-		if (sbeTypeId == ODYSSEY_SBE_DUMP)
-			targetIdx = getFapiUnitPos(target);
-		else if (sbeTypeId == PROC_SBE_DUMP)
-			targetIdx = pdbg_target_index(target);
-
+		auto targetIdx = pdbg_target_index(target);
 		if (targetIdx != failingUnit) {
 			continue;
 		}


### PR DESCRIPTION
Earlier we used to compare the FAPI unit position with the failing unit ID for Odyssey SBE dump collection, while for P10 chip, we compared it with PDBG target index. Now along with changes made in PDBG we only compare PDBG target index with the failing unit ID for both the P10 and Odyssey chip while collecting SBE dump.

Test Results:

odyssey
 p[62]
  mp[6,7]
  perv[28,35]
 p[2]
  mp[68,69]
  perv[51,58]
 p[6]
  mp[70,71]
  perv[60,67]
/usr/bin/edbg ecmdquery chips -dc
root:/tmp/src# busctl --verbose call org.open_power.Dump.Manager /org/openpower/dump xyz.openbmc_project.Dump.Create CreateDump a{sv} 3 "com.ibm.Dump.Create.CreateParameters.DumpType" s "com.ibm.Dump.Create.DumpType.MemoryBufferSBE" "com.ibm.Dump.Create.CreateParameters.ErrorLogId" t 0xDEADBEEF
 "com.ibm.Dump.Create.CreateParameters.FailingUnitId" t 62
MESSAGE "o" {
        OBJECT_PATH "/xyz/openbmc_project/dump/sbe/entry/40000001";
};

Apr 08 11:31:42 phosphor-dump-manager[22626]: Creating dump with dumpPath(/var/lib/phosphor-debug-collector/msbedump/40000001) id(40000001) available space(102400) eid(deadbeef) dump type(11) failing unit(62)
Apr 08 11:31:42 pvm_dump_offload[22483]: Watch interfaceAdded path (/xyz/openbmc_project/dump/sbe/entry/40000001)
Apr 08 11:34:27 phosphor-dump-manager[22638]: Collecting SBE dump: path=/tmp/dump_40000001_1712575902/plat_dump, id=40000001, chip position=62
Apr 08 11:34:27 phosphor-dump-manager[22638]: PDBG Initilization started
Apr 08 11:34:27 phosphor-dump-manager[22638]: err: ody_extract_sbe_rc:275 The external halt_req input was active.
Apr 08 11:34:27 phosphor-dump-manager[22638]: err: ody_extract_sbe_rc:473 Instruction machine check at Address = FFF80014
Apr 08 11:34:27 phosphor-dump-manager[22638]: extract_sbe_rc for target=/proc0/pib/perv12/mc0/mi0/mcc1/omi1/ocmb0 returned rc=0x7EC76F54 and SBE Recovery Action=0x00000000
Apr 08 11:34:27 phosphor-dump-manager[22638]: Collection process completed
Apr 08 11:34:27 phosphor-dump-manager[22638]: SBE dump collection completed successfully
Apr 08 11:34:27 phosphor-dump-manager[22667]: Could not fetch start time for 40000001. Setting manually
Apr 08 11:34:27 phosphor-dump-manager[22667]: Could not fetch end time for 40000001. Setting manually
Apr 08 11:34:27 phosphor-dump-manager[22677]: plat_dump/40000001.0_62_SbeData_ody_ody_pibmem_dump
Apr 08 11:34:27 phosphor-dump-manager[22677]: plat_dump/40000001.0_62_SbeData_ody_ody_pibms_reg_dump
Apr 08 11:34:27 phosphor-dump-manager[22677]: plat_dump/40000001.0_62_SbeData_ody_ody_ppe_state
Apr 08 11:34:27 phosphor-dump-manager[22677]: plat_dump/40000001.0_62_SbeData_ody_ody_sbe_localreg_dump
Apr 08 11:34:27 phosphor-dump-manager[22677]: info.yaml
Apr 08 11:34:27 phosphor-dump-manager[22626]: Adding Dump Header :/usr/share/dreport.d/include.d/gendumpheader
Apr 08 11:34:29 pvm_dump_offload[22483]: Watch propertiesChanged object path (/xyz/openbmc_project/dump/sbe/entry/40000001)
Apr 08 11:34:29 pvm_dump_offload[22483]: Queue enqueue dump (/xyz/openbmc_project/dump/sbe/entry/40000001) size of Q (0)
Apr 08 11:34:29 phosphor-dump-manager[22626]: Mon Apr  8 11:34:29 UTC 2024 Successfully completed
Apr 08 11:34:29 phosphor-dump-manager[499]: OriginatorId is not provided
Apr 08 11:34:29 phosphor-dump-manager[499]: OriginatorType is not provided. Replacing the string with the default value
Apr 08 11:34:29 pvm_dump_offload[22483]: Watch interfaceAdded path (/xyz/openbmc_project/dump/bmc/entry/3)
Apr 08 11:34:29 phosphor-dump-manager[22626]: BMC dump initiated o "/xyz/openbmc_project/dump/bmc/entry/3"
Apr 08 11:34:29 phosphor-dump-manager[499]: Dump packaging completed