### PR TITLE
libphal: PHAL API for returning FRU Type

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -32,7 +32,16 @@ if test "x$enable_libphal" = "xyes"; then
 fi
 
 AC_LANG([C++])
-AX_CXX_COMPILE_STDCXX_17([noext])
+# Adding the required C++ version directly is not typically recommended
+# practice. However, Autotools does not support AX_CXX_COMPILE_STDCXX_23 or
+# AX_CXX_COMPILE_STDCXX for version 23.
+saved_CXXFLAGS=$CXXFLAGS
+CXXFLAGS="$saved_CXXFLAGS -std=c++23"
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([#include <expected>],
+                                   [std::expected<int, int> testObj;])],
+                  [saved_CXXFLAGS="$saved_CXXFLAGS -std=c++23"],
+                  [AC_MSG_ERROR([C++23 is not supported, but it is required])])
+CXXFLAGS=$saved_CXXFLAGS
 
 AC_PROG_CXX
 AC_PROG_LIBTOOL

--- a/libphal/libphal.H
+++ b/libphal/libphal.H
@@ -9,6 +9,8 @@ extern "C" {
 
 #include <attributes_info.H>
 #include <vector>
+#include <optional>
+#include <expected>
 
 namespace openpower::phal
 {
@@ -152,6 +154,9 @@ void threadStopProc(struct pdbg_target *proc);
 
 namespace pdbg
 {
+using LocationCode = std::string;
+using FRUType = uint8_t;
+
 /**
  * @brief wrapper function to Initialise the pdbg library targeting system
  *        based on user provided back-end and device tree.
@@ -277,6 +282,32 @@ bool isSbeVitalAttnActive(struct pdbg_target *proc);
  * consider control still in hostboot
  */
 bool hasControlTransitionedToHost();
+
+/**
+ * @brief Get unexpanded location code
+ *
+ * @details An api to get an unexpanded location code corresponding to
+ *          a given expanded location code. Unexpanded location codes
+ *          give the location of the FRU in the system.
+ *
+ * @param[in] locCode - Location code in expanded format.
+ *
+ * @return Location code as string which will be in un-expanded format or
+ *         empty optional on failure.
+ */
+std::optional<LocationCode> getUnexpandedLocCode(const LocationCode &locCode);
+
+/**
+ * @brief Retrieves FRU information for the provided location codes.
+ *
+ * Location codes can be in either expanded or unexpanded format.
+ *
+ * @param[in] locationCode A FRU location code to fetch its type.
+ *
+ * @return FRUType or error code
+ */
+std::expected<FRUType, openpower::phal::exception::ERR_TYPE>
+    getFRUType(const LocationCode &locationCode) noexcept;
 
 } // namespace pdbg
 

--- a/libphal/phal_exception.H
+++ b/libphal/phal_exception.H
@@ -8,19 +8,20 @@
 
 namespace openpower::phal
 {
-//taken from error_info_defs.H, including the header file breaks logging and
-//debug collector as they need to include ekb in include path
-enum errlSeverity_t
-{
-    FAPI2_ERRL_SEV_UNDEFINED     = 0x00, /// Used internally by ffdc mechanism
-    FAPI2_ERRL_SEV_RECOVERED     = 0x10, /// Not seen by customer
-    FAPI2_ERRL_SEV_PREDICTIVE    = 0x20, /// Error recovered but customer will see
-    FAPI2_ERRL_SEV_UNRECOVERABLE = 0x40  /// Unrecoverable, general
+// taken from error_info_defs.H, including the header file breaks logging and
+// debug collector as they need to include ekb in include path
+enum errlSeverity_t {
+	FAPI2_ERRL_SEV_UNDEFINED = 0x00, /// Used internally by ffdc mechanism
+	FAPI2_ERRL_SEV_RECOVERED = 0x10, /// Not seen by customer
+	FAPI2_ERRL_SEV_PREDICTIVE =
+	    0x20, /// Error recovered but customer will see
+	FAPI2_ERRL_SEV_UNRECOVERABLE = 0x40 /// Unrecoverable, general
 };
 
 namespace fs = std::filesystem;
-//slid, severity, fd, filename
-using FFDCFileList = std::unordered_map<uint16_t, std::tuple<uint8_t, int, fs::path>>;
+// slid, severity, fd, filename
+using FFDCFileList =
+    std::unordered_map<uint16_t, std::tuple<uint8_t, int, fs::path>>;
 namespace exception
 {
 
@@ -125,7 +126,7 @@ class SbeError final : public phalError
 	int getFd() const noexcept
 	{
 		if (!ffdcFileList.empty()) {
-			const auto& tuple = ffdcFileList.begin()->second;
+			const auto &tuple = ffdcFileList.begin()->second;
 			return std::get<1>(tuple);
 		}
 		return -1;
@@ -135,14 +136,14 @@ class SbeError final : public phalError
 	std::string getFileName() const noexcept
 	{
 		if (!ffdcFileList.empty()) {
-    		const auto& tuple = ffdcFileList.begin()->second;
+			const auto &tuple = ffdcFileList.begin()->second;
 			return std::get<2>(tuple);
 		}
 		return "";
 	}
 
 	/* return ffdcmap information */
-	const FFDCFileList& getFfdcFileList() const noexcept
+	const FFDCFileList &getFfdcFileList() const noexcept
 	{
 		return ffdcFileList;
 	}
@@ -150,6 +151,7 @@ class SbeError final : public phalError
 	{
 		return ffdcFileList.size();
 	}
+
        private:
 	/* Error type */
 	ERR_TYPE type;

--- a/libphal/phal_exception.H
+++ b/libphal/phal_exception.H
@@ -49,6 +49,8 @@ enum ERR_TYPE {
 	PDBG_FSI_WRITE_FAIL,
 	SBE_DUMP_IS_ALREADY_COLLECTED,
 	SBE_INTERNAL_FFDC_DATA,
+	ATTR_LOC_CODE_NOT_VALID,
+	ATTR_LOC_CODE_NOT_FOUND,
 };
 constexpr uint16_t DEFAULT_SLID = 0;
 // Error type to message map.
@@ -75,6 +77,8 @@ const errMsgMapType errMsgMap = {
     {PDBG_FSI_READ_FAIL, "FSI read failed"},
     {PDBG_FSI_WRITE_FAIL, "FSI write failed"},
     {SBE_DUMP_IS_ALREADY_COLLECTED, "Dump from this SBE is already collected"},
+    {ATTR_LOC_CODE_NOT_VALID, "The location code is not valid"},
+    {ATTR_LOC_CODE_NOT_FOUND, "The location code is not found in device tree"},
 };
 // phal specific errors base exception class
 struct phalError : public std::exception {

--- a/libphal/phal_pdbg.C
+++ b/libphal/phal_pdbg.C
@@ -67,19 +67,19 @@ bool isTgtFunctional(struct pdbg_target *target)
 bool is_ody_ocmb_chip(struct pdbg_target *target)
 {
 	const uint16_t ODYSSEY_CHIP_ID = 0x60C0;
-        const uint8_t ATTR_TYPE_OCMB_CHIP = 75;
-	ATTR_CHIP_ID_type ODYSSEY_CHIP_ID = 
+	const uint8_t ATTR_TYPE_OCMB_CHIP = 75;
+	ATTR_CHIP_ID_type ODYSSEY_CHIP_ID =
 	ATTR_TYPE_type type;
 	DT_GET_PROP(ATTR_TYPE, target, type);
-        if(type != ATTR_TYPE_OCMB_CHIP) {
-                                return false;
-        }
-        ATTR_CHIP_ID_type chipId = 0;
-        pdbg_target_get_attribute(ATTR_CHIP_ID, target,chipId);
-        if(chipId == ODYSSEY_CHIP_ID) {
-                return true;
-        }
-        return false;
+	if(type != ATTR_TYPE_OCMB_CHIP) {
+				return false;
+	}
+	ATTR_CHIP_ID_type chipId = 0;
+	pdbg_target_get_attribute(ATTR_CHIP_ID, target,chipId);
+	if(chipId == ODYSSEY_CHIP_ID) {
+		return true;
+	}
+	return false;
 }*/
 
 bool isPrimaryProc(struct pdbg_target *proc)
@@ -300,24 +300,27 @@ bool isSbeVitalAttnActive(struct pdbg_target *proc)
 
 bool hasControlTransitionedToHost()
 {
-  //Read the scratch register to find if the control has moved to phyp (Host)
-  auto pibTarget = pdbg_target_from_path(nullptr, "/proc0/pib");
+	// Read the scratch register to find if the control has moved to phyp
+	// (Host)
+	auto pibTarget = pdbg_target_from_path(nullptr, "/proc0/pib");
 
-  uint64_t l_coreScratchRegData = 0xFFFFFFFFFFFFFFFFull;
-  // HB changes the below core scratch reg as one of the last instructions that is run,
-  // so if that is zero then we're in phyp
-  uint64_t l_coreScratchRegAddr = 0x4602F489;
+	uint64_t l_coreScratchRegData = 0xFFFFFFFFFFFFFFFFull;
+	// HB changes the below core scratch reg as one of the last instructions
+	// that is run, so if that is zero then we're in phyp
+	uint64_t l_coreScratchRegAddr = 0x4602F489;
 
-  // Is there any error in reading the scom address, consider control is in hostboot
-  if (pib_read(pibTarget, l_coreScratchRegAddr, &l_coreScratchRegData))
-  {
-    // If unable to read the register, by default consider the control is in hostboot
-    log(level::ERROR, "scom read error: 0x%X", l_coreScratchRegAddr );
-    return false;
-  }
+	// Is there any error in reading the scom address, consider control is
+	// in hostboot
+	if (pib_read(pibTarget, l_coreScratchRegAddr, &l_coreScratchRegData)) {
+		// If unable to read the register, by default consider the
+		// control is in hostboot
+		log(level::ERROR, "scom read error: 0x%X",
+		    l_coreScratchRegAddr);
+		return false;
+	}
 
-  // If the register reads zero, return control moved to host.
-  return (l_coreScratchRegData == 0);
+	// If the register reads zero, return control moved to host.
+	return (l_coreScratchRegData == 0);
 }
 
 } // namespace openpower::phal::pdbg


### PR DESCRIPTION
We need to capture the DRAM manufacturer ID in the PEL (error log) whenever a DIMM is callout/guarded/deconfigured. This is essential for identifying the DRAM manufacturer since IBM sources DRAM from different vendors.

The VPD will store the DRAM manufacturer ID in the DIMM inventory using the VINI DBus interface. The PEL daemon must retrieve this VPD keyword and add it to a new user data section.

The PEL daemon is unable to determine if a callout/guarded/deconfigured location code corresponds to a DIMM. Therefore, PHAL needs to offer an API that can return the FRU type by utilizing the PHAL device tree.

Change-Id: I738697c2b28885419fdcda60814e8ea7312ac8b2