### PR TITLE
libphal: Fix libphal traces

### DIFF
--- a/libphal/log.C
+++ b/libphal/log.C
@@ -16,6 +16,7 @@ void log(level logLevel, const char *fmt, ...)
 
 	vfprintf(stdout, fmt, ap);
 	std::cout << "\n";
+	fflush(stdout);
 
 	va_end(ap);
 }

--- a/libphal/phal_pdbg.C
+++ b/libphal/phal_pdbg.C
@@ -439,7 +439,7 @@ std::expected<FRUType, phal_exception::ERR_TYPE>
 		return std::unexpected(phal_exception::DEVTREE_ATTR_READ_FAIL);
 	}
 	log(level::ERROR, "Given location code %s is not found ",
-	    unExpandedLocCode);
+	    unExpandedLocCode.c_str());
 	return std::unexpected(phal_exception::ATTR_LOC_CODE_NOT_FOUND);
 }
 } // namespace openpower::phal::pdbg


### PR DESCRIPTION
libphal trace is broken and the traces are not flushed to the journal. So, using fflush to fix this issue.

Also, log() method is expecting a c string. so, type casting the argument.

Change-Id: I61b77f71a02504a86fc144832f6fa2cb1410a21c
Signed-off-by: SwethaParasa <parasa.swetha1@ibm.com>